### PR TITLE
Syntax Highlighting Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "monaco"
 version = "0.3.0"
-source = "git+https://github.com/b0x-Cub3d/rust-monaco#69764ba222c2665eabaaf5091609b2c7a4cf037f"
+source = "git+https://github.com/b0x-Cub3d/rust-monaco?rev=2910753bda2f2091f8d417e34b37a395bee61388#2910753bda2f2091f8d417e34b37a395bee61388"
 dependencies = [
  "js-sys",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "monaco"
 version = "0.3.0"
-source = "git+https://github.com/b0x-Cub3d/rust-monaco?rev=2910753bda2f2091f8d417e34b37a395bee61388#2910753bda2f2091f8d417e34b37a395bee61388"
+source = "git+https://github.com/b0x-Cub3d/rust-monaco?rev=cd679f41310896309f5e2464c22c51d348af22de#cd679f41310896309f5e2464c22c51d348af22de"
 dependencies = [
  "js-sys",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "monaco"
 version = "0.3.0"
-source = "git+https://github.com/siku2/rust-monaco?rev=cac3ea13d4467966ac3d969d5b9c3c949209f637#cac3ea13d4467966ac3d969d5b9c3c949209f637"
+source = "git+https://github.com/b0x-Cub3d/rust-monaco#69764ba222c2665eabaaf5091609b2c7a4cf037f"
 dependencies = [
  "js-sys",
  "paste",
@@ -754,6 +754,7 @@ name = "swim"
 version = "0.1.0"
 dependencies = [
  "gloo",
+ "js-sys",
  "monaco",
  "strum",
  "strum_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ strum_macros = "0.24"
 
 # UI
 gloo = {version = "0.8.0", features = ["futures"]}
-monaco = { git = "https://github.com/siku2/rust-monaco", rev = "cac3ea13d4467966ac3d969d5b9c3c949209f637", features = ["yew-components"]  }
+monaco = { git = "https://github.com/b0x-Cub3d/rust-monaco", features = ["yew-components"]  }
 stylist = {version = "0.12.0", features = ["yew", "parser"]}
 wasm-bindgen = "0.2.83"
 web-sys = {version = "0.3.60", features = ["Event", "HtmlInputElement"]}
+js-sys = "0.3.60"
 yew = {version = "0.20.0", features = ["csr"] }
 wasm-bindgen-futures = "0.4.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ strum_macros = "0.24"
 
 # UI
 gloo = {version = "0.8.0", features = ["futures"]}
-monaco = { git = "https://github.com/b0x-Cub3d/rust-monaco", rev = "2910753bda2f2091f8d417e34b37a395bee61388", features = ["yew-components"]  }
+monaco = { git = "https://github.com/b0x-Cub3d/rust-monaco", rev = "cd679f41310896309f5e2464c22c51d348af22de", features = ["yew-components"]  }
 stylist = {version = "0.12.0", features = ["yew", "parser"]}
 wasm-bindgen = "0.2.83"
 web-sys = {version = "0.3.60", features = ["Event", "HtmlInputElement"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ strum_macros = "0.24"
 
 # UI
 gloo = {version = "0.8.0", features = ["futures"]}
-monaco = { git = "https://github.com/b0x-Cub3d/rust-monaco", features = ["yew-components"]  }
+monaco = { git = "https://github.com/b0x-Cub3d/rust-monaco", rev = "2910753bda2f2091f8d417e34b37a395bee61388", features = ["yew-components"]  }
 stylist = {version = "0.12.0", features = ["yew", "parser"]}
 wasm-bindgen = "0.2.83"
 web-sys = {version = "0.3.60", features = ["Event", "HtmlInputElement"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ monaco = { git = "https://github.com/b0x-Cub3d/rust-monaco", rev = "cd679f413108
 stylist = {version = "0.12.0", features = ["yew", "parser"]}
 wasm-bindgen = "0.2.83"
 web-sys = {version = "0.3.60", features = ["Event", "HtmlInputElement"]}
-js-sys = "0.3.60"
+js-sys = "0.3.61"
 yew = {version = "0.20.0", features = ["csr"] }
 wasm-bindgen-futures = "0.4.33"

--- a/src/parser/parser_structs_and_enums.rs
+++ b/src/parser/parser_structs_and_enums.rs
@@ -2,17 +2,8 @@ pub mod instruction_tokenization {
     use std::default::Default;
 
     #[derive(Default, Debug, Clone, PartialEq, Eq)]
-    ///Wrapper for all information gathered in the Parser/Assembler about the written program.
-    pub struct ProgramInfo {
-        pub instructions: Vec<Instruction>,
-        pub comments_line_and_column: Vec<[u32; 2]>,
-        pub data_starting_line: u32,
-        pub text_starting_line: u32,
-    }
-
-    ///A collection of all relevant information found about an instruction in the Parser/Assembler
-    #[derive(Default, Debug, Clone, PartialEq, Eq)]
     pub struct Instruction {
+        pub tokens: Vec<String>,
         pub operator: Token,
         pub operands: Vec<Token>,
         pub binary: u32,
@@ -68,6 +59,7 @@ pub mod instruction_tokenization {
         LabelAssignmentError,
         LabelMultipleDefinition,
         LabelNotFound,
+        JALRRDRegisterZero,
     }
 
     //this enum is used for the fn read_operands to choose the types of operands expected for an instruction type

--- a/src/parser/preprocessing.rs
+++ b/src/parser/preprocessing.rs
@@ -9,16 +9,15 @@ use crate::parser::parser_structs_and_enums::instruction_tokenization::{
 };
 use std::collections::HashMap;
 
-///Takes the initial string of the program given by the editor and turns it into a vector of Line,
-/// a struct that holds tokens and the original line number, and finds the starting point for all comments.
-pub fn tokenize_instructions(program: String) -> (Vec<Line>, Vec<[u32; 2]>) {
+///This function takes the initial string of the program given by the editor and turns it into a vector of Line,
+/// a struct that holds tokens and the original line number
+pub fn tokenize_instructions(program: String) -> Vec<Line> {
     let mut line_vec: Vec<Line> = Vec::new();
     let mut token: Token = Token {
         token_name: "".to_string(),
         starting_column: 0,
         token_type: Unknown,
     };
-    let mut comments: Vec<[u32; 2]> = Vec::new();
 
     for (i, line_of_program) in program.lines().enumerate() {
         let mut line_of_tokens = Line {
@@ -29,7 +28,6 @@ pub fn tokenize_instructions(program: String) -> (Vec<Line>, Vec<[u32; 2]>) {
 
         for (j, char) in line_of_program.chars().enumerate() {
             if char == '#' {
-                comments.push([i as u32, j as u32]);
                 break;
             };
             if char != ' ' {
@@ -60,7 +58,7 @@ pub fn tokenize_instructions(program: String) -> (Vec<Line>, Vec<[u32; 2]>) {
         }
     }
 
-    (line_vec, comments)
+    line_vec
 }
 
 ///This function takes the vector of lines created by tokenize instructions and turns them into instructions

--- a/src/tests/parser/operand_reading.rs
+++ b/src/tests/parser/operand_reading.rs
@@ -203,7 +203,7 @@ mod read_label_absolute_tests {
 
     #[test]
     fn read_label_absolute_returns_address_of_instruction() {
-        let (lines, _comments) = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nsw $t1, 400($t2)\naddi $t1, $t2, 400".to_string());
+        let lines = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nsw $t1, 400($t2)\naddi $t1, $t2, 400".to_string());
         let mut instruction_list: Vec<Instruction> = build_instruction_list_from_lines(lines);
         confirm_operand_commas(&mut instruction_list);
         expand_pseudo_instruction(&mut instruction_list);
@@ -218,7 +218,7 @@ mod read_label_absolute_tests {
 
     #[test]
     fn read_label_absolute_returns_error_if_label_cannot_be_found() {
-        let (lines, _comments) = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nsave_to_memory: sw $t1, 400($t2)\naddi $t1, $t2, 400".to_string());
+        let lines = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nsave_to_memory: sw $t1, 400($t2)\naddi $t1, $t2, 400".to_string());
         let mut instruction_list: Vec<Instruction> = build_instruction_list_from_lines(lines);
         confirm_operand_commas(&mut instruction_list);
         expand_pseudo_instruction(&mut instruction_list);
@@ -242,7 +242,7 @@ mod read_label_relative_tests {
 
     #[test]
     fn read_label_relative_returns_correct_value_for_instruction_above_current() {
-        let (lines, _comments) = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nsw $t1, 400($t2)\naddi $t1, $t2, 400".to_string());
+        let lines = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nsw $t1, 400($t2)\naddi $t1, $t2, 400".to_string());
         let mut instruction_list: Vec<Instruction> = build_instruction_list_from_lines(lines);
         confirm_operand_commas(&mut instruction_list);
         expand_pseudo_instruction(&mut instruction_list);
@@ -257,7 +257,7 @@ mod read_label_relative_tests {
 
     #[test]
     fn read_label_relative_returns_correct_value_for_instruction_below_current() {
-        let (lines, _comments) = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nstore_in_memory: sw $t1, 400($t2)\naddi $t1, $t2, 400".to_string());
+        let lines = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nstore_in_memory: sw $t1, 400($t2)\naddi $t1, $t2, 400".to_string());
         let mut instruction_list: Vec<Instruction> = build_instruction_list_from_lines(lines);
         confirm_operand_commas(&mut instruction_list);
         expand_pseudo_instruction(&mut instruction_list);

--- a/src/tests/parser/parser_main.rs
+++ b/src/tests/parser/parser_main.rs
@@ -8,27 +8,19 @@ mod parser_main_function_tests {
         let results =
             parser("lw $t1, 512($t1)\nadd $t1, $s6, $t2\naddi $t1, $t2, 43690".to_string());
 
-        let length = results.0.instructions.len();
+        let length = results.0.len();
 
         for i in 0..length {
-            print_instruction_struct_contents(results.0.instructions.get(i).unwrap());
+            print_instruction_struct_contents(results.0.get(i).unwrap());
         }
-        assert_eq!(
-            results.0.instructions[0].binary,
-            0b10001101001010010000001000000000
-        );
-        assert_eq!(
-            results.0.instructions[1].binary,
-            0b00000010110010100100100000100000
-        );
-        assert_eq!(
-            results.0.instructions[2].binary,
-            0b00100001010010011010101010101010
-        );
+        assert_eq!(results.0[0].binary, 0b10001101001010010000001000000000);
+        assert_eq!(results.0[1].binary, 0b00000010110010100100100000100000);
+        assert_eq!(results.0[2].binary, 0b00100001010010011010101010101010);
     }
 }
 
 mod read_instructions_tests {
+    use crate::parser::parser_structs_and_enums::instruction_tokenization::ErrorType::JALRRDRegisterZero;
     use crate::tests::parser::parser_main::helper_functions::simulate_parser;
 
     #[test]
@@ -607,6 +599,73 @@ mod read_instructions_tests {
             0b01000101000000001111111111111110
         );
     }
+
+    #[test]
+    fn read_instruction_jalr_with_rd() {
+        let instruction_list = simulate_parser("jalr $t1, $t2".to_string());
+
+        assert_eq!(
+            instruction_list[0].binary,
+            0b00000001010000000100100000001001
+        );
+    }
+
+    #[test]
+    fn read_instruction_jalr_without_rd() {
+        let instruction_list = simulate_parser("jalr $t2".to_string());
+
+        assert_eq!(
+            instruction_list[0].binary,
+            0b00000001010000001111100000001001
+        );
+    }
+
+    #[test]
+    fn read_instruction_jalr_creates_error_with_rd_equal_0() {
+        let instruction_list = simulate_parser("jalr $zero, $t2".to_string());
+
+        assert_eq!(instruction_list[0].errors[0].error_name, JALRRDRegisterZero);
+    }
+
+    #[test]
+    fn read_instruction_ld() {
+        let instruction_list = simulate_parser("ld $t1, 512($t1)".to_string());
+
+        assert_eq!(
+            instruction_list[0].binary,
+            0b11011101001010010000001000000000
+        );
+    }
+
+    #[test]
+    fn read_instruction_sd() {
+        let instruction_list = simulate_parser("sd $t1, 512($t1)".to_string());
+
+        assert_eq!(
+            instruction_list[0].binary,
+            0b11111101001010010000001000000000
+        );
+    }
+
+    #[test]
+    fn read_instruction_ldc1() {
+        let instruction_list = simulate_parser("ldc1 $f9, 512($t1)".to_string());
+
+        assert_eq!(
+            instruction_list[0].binary,
+            0b11010101001010010000001000000000
+        );
+    }
+
+    #[test]
+    fn read_instruction_sdc1() {
+        let instruction_list = simulate_parser("sdc1 $f9, 512($t1)".to_string());
+
+        assert_eq!(
+            instruction_list[0].binary,
+            0b11110101001010010000001000000000
+        );
+    }
 }
 use crate::parser::parser_main::place_binary_in_middle_of_another;
 #[test]
@@ -643,7 +702,7 @@ mod helper_functions {
     pub fn simulate_parser(mut file_string: String) -> Vec<Instruction> {
         file_string = file_string.to_lowercase();
 
-        let (lines, _comments) = tokenize_instructions(file_string);
+        let lines = tokenize_instructions(file_string);
         let mut instruction_list: Vec<Instruction> = build_instruction_list_from_lines(lines);
         confirm_operand_commas(&mut instruction_list);
         expand_pseudo_instruction(&mut instruction_list);

--- a/src/tests/parser/preprocessing.rs
+++ b/src/tests/parser/preprocessing.rs
@@ -77,7 +77,7 @@ fn tokenize_instructions_works_basic_version() {
     };
 
     let correct_result = vec![line_0, line_1, line_2];
-    assert_eq!(result.0, correct_result);
+    assert_eq!(result, correct_result);
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn tokenize_instruction_handles_no_spaces_between_commas() {
     };
 
     let correct_result = vec![line_0, line_1];
-    assert_eq!(result.0, correct_result);
+    assert_eq!(result, correct_result);
 }
 
 #[test]
@@ -171,7 +171,7 @@ fn tokenize_instruction_handles_comma_after_space() {
     };
 
     let correct_result = vec![line_0];
-    assert_eq!(result.0, correct_result);
+    assert_eq!(result, correct_result);
 }
 
 #[test]
@@ -213,30 +213,12 @@ fn tokenize_instructions_ignores_comments() {
     };
 
     let correct_result = vec![line_0, line_2, line_3];
-    assert_eq!(results.0, correct_result);
-}
-
-#[test]
-fn tokenize_instructions_recognizes_comments() {
-    let results = tokenize_instructions("Addi $t1, $t2, 300\n# this is a comment\nadd $t1, $t2, $t3\n#I'm making a note here. Huge comment".to_string());
-    assert_eq!(results.1[0][0], 1);
-    assert_eq!(results.1[0][1], 0);
-    assert_eq!(results.1[1][0], 3);
-    assert_eq!(results.1[1][1], 0);
-}
-
-#[test]
-fn tokenize_instructions_recognizes_comments_middle_of_line() {
-    let results = tokenize_instructions("Addi $t1, $t2, 300 # this is a comment\nadd $t1, $t2, $t3#I'm making a note here. Huge comment".to_string());
-    assert_eq!(results.1[0][0], 0);
-    assert_eq!(results.1[0][1], 19);
-    assert_eq!(results.1[1][0], 1);
-    assert_eq!(results.1[1][1], 17);
+    assert_eq!(results, correct_result);
 }
 
 #[test]
 fn build_instruction_list_from_lines_works_basic_version() {
-    let (lines, _comments) =
+    let lines =
         tokenize_instructions("add $t1, $t2, $t3\nlw $t1, 400($t1)\naddi $t1, 100".to_string());
     let result = build_instruction_list_from_lines(lines.clone());
 
@@ -275,7 +257,7 @@ fn build_instruction_list_from_lines_works_basic_version() {
 
 #[test]
 fn build_instruction_list_from_lines_works_on_line_label() {
-    let (lines, _comments) = tokenize_instructions(
+    let lines = tokenize_instructions(
         "add $t1, $t2, $t3\nLoad_from_memory: lw $t1, 400($t1)\naddi $t1, 100".to_string(),
     );
     let result = build_instruction_list_from_lines(lines.clone());
@@ -321,7 +303,7 @@ fn build_instruction_list_from_lines_works_on_line_label() {
 
 #[test]
 fn build_instruction_list_from_lines_works_off_line_label() {
-    let (lines, _comments) = tokenize_instructions(
+    let lines = tokenize_instructions(
         "add $t1, $t2, $t3\nLoad_from_memory:\nlw $t1, 400($t1)\naddi $t1, 100".to_string(),
     );
     let result = build_instruction_list_from_lines(lines.clone());
@@ -367,7 +349,7 @@ fn build_instruction_list_from_lines_works_off_line_label() {
 
 #[test]
 fn build_instruction_list_generates_error_on_double_label() {
-    let (lines, _comments) = tokenize_instructions(
+    let lines = tokenize_instructions(
         "lw $t1, 400($zero)\nLabel1:\nLabel2: add $t1, $t2, $t3\n".to_string(),
     );
     let result = build_instruction_list_from_lines(lines);
@@ -376,7 +358,7 @@ fn build_instruction_list_generates_error_on_double_label() {
 
 #[test]
 fn build_instruction_list_generates_error_on_label_on_last_line() {
-    let (lines, _comments) =
+    let lines =
         tokenize_instructions("lw $t1, 400($zero)\nadd $t1, $t2, $t3\nlabel:\n".to_string());
     let result = build_instruction_list_from_lines(lines);
     assert_eq!(result[2].errors[0].error_name, LabelAssignmentError);
@@ -384,13 +366,11 @@ fn build_instruction_list_generates_error_on_label_on_last_line() {
 
 #[test]
 fn confirm_operand_commas_removes_properly_placed_commas() {
-    let (lines, _comments) =
-        tokenize_instructions("Add $t1, $t2, $t3\nlw $t1, 400($t2)".to_string());
+    let lines = tokenize_instructions("Add $t1, $t2, $t3\nlw $t1, 400($t2)".to_string());
     let mut result = build_instruction_list_from_lines(lines);
     confirm_operand_commas(&mut result);
 
-    let (correct_lines, _comments) =
-        tokenize_instructions("Add $t1  $t2  $t3\nlw $t1  400($t2)".to_string());
+    let correct_lines = tokenize_instructions("Add $t1  $t2  $t3\nlw $t1  400($t2)".to_string());
     let correct_result = build_instruction_list_from_lines(correct_lines);
 
     assert_eq!(correct_result, result);
@@ -398,8 +378,7 @@ fn confirm_operand_commas_removes_properly_placed_commas() {
 
 #[test]
 fn confirm_operand_commas_generates_error_on_missing_commas() {
-    let (lines, _comments) =
-        tokenize_instructions("Add $t1, $t2, $t3\nlw $t1 400($t2)".to_string());
+    let lines = tokenize_instructions("Add $t1, $t2, $t3\nlw $t1 400($t2)".to_string());
     let mut result = build_instruction_list_from_lines(lines);
     confirm_operand_commas(&mut result);
     let correct_error = Error {
@@ -411,7 +390,7 @@ fn confirm_operand_commas_generates_error_on_missing_commas() {
 
 #[test]
 fn create_label_map_generates_map_on_no_errors() {
-    let (lines, _comments) = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nstore_in_memory: sw $t1, 400($t2)".to_string());
+    let lines = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nstore_in_memory: sw $t1, 400($t2)".to_string());
     let mut instruction_list: Vec<Instruction> = build_instruction_list_from_lines(lines);
     confirm_operand_commas(&mut instruction_list);
     expand_pseudo_instruction(&mut instruction_list);
@@ -428,7 +407,7 @@ fn create_label_map_generates_map_on_no_errors() {
 
 #[test]
 fn create_label_map_pushes_errors_instead_of_inserting_duplicate_label_name() {
-    let (lines, _comments) = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nload_from_memory: lw $t2, 400($t2)".to_string());
+    let lines = tokenize_instructions("add $t1, $t2, $t3\nload_from_memory: lw $t1 400($t2)\nadd $t1, #t2, $t3\nload_from_memory: lw $t2, 400($t2)".to_string());
     let mut instruction_list: Vec<Instruction> = build_instruction_list_from_lines(lines);
     confirm_operand_commas(&mut instruction_list);
     expand_pseudo_instruction(&mut instruction_list);

--- a/src/tests/parser/preprocessing.rs
+++ b/src/tests/parser/preprocessing.rs
@@ -390,7 +390,7 @@ fn confirm_operand_commas_generates_error_on_missing_commas() {
 
 #[test]
 fn confirm_operands_does_not_break_when_instruction_has_no_operands() {
-    let (lines, _comments) = tokenize_instructions("Add $t1, $t2, $t3\nlw".to_string());
+    let lines = tokenize_instructions("Add $t1, $t2, $t3\nlw".to_string());
     let _result = build_instruction_list_from_lines(lines);
 }
 


### PR DESCRIPTION
While this had no significant changes to the codebase, most of the work was done on a forked version of rust-monaco. The fork had modifications to the Monaco Editor JavaScript source file to have it recognize our custom set of instructions. This should close issues #122 and #72.