### PR TITLE
Halt the emulation core on `syscall` and errors

### DIFF
--- a/src/emulation_core/datapath.rs
+++ b/src/emulation_core/datapath.rs
@@ -30,12 +30,14 @@ pub trait Datapath {
     /// Execute a single instruction based on the current state of the
     /// datapath. Should the datapath support stages, if the datapath is
     /// midway through a stage, the current instruction will be finished
-    /// instead of executing a new instruction.
+    /// instead of executing a new instruction. Should the datapath be in
+    /// a "halted" state, behavior is undefined.
     fn execute_instruction(&mut self);
 
     /// Execute a single stage of execution based on the current state of
     /// the datapath. Should the datapath not support stages, assume the
-    /// same behavior as [`Self::execute_instruction()`].
+    /// same behavior as [`Self::execute_instruction()`]. Should the
+    /// datapath be in a "halted" state, behavior is undefined.
     fn execute_stage(&mut self);
 
     /// Retrieve the data in the register indicated by the provided enum.
@@ -45,6 +47,10 @@ pub trait Datapath {
 
     /// Retrieve all memory as-is.
     fn get_memory(&self) -> &Self::MemoryType;
+
+    /// Returns if the datapath is in a "halted" or "stopped" state. This may
+    /// be true in the case where an error had occurred previously.
+    fn is_halted(&self) -> bool;
 
     /// Restore the datapath to its default state.
     fn reset(&mut self);

--- a/src/emulation_core/mips/constants.rs
+++ b/src/emulation_core/mips/constants.rs
@@ -1,5 +1,7 @@
 use super::control_signals::RegWidth;
 
+pub const FUNCT_SYSCALL: u8 = 0b001100;
+
 pub const FUNCT_ADD: u8 = 0b100000;
 pub const FUNCT_SUB: u8 = 0b100010;
 pub const FUNCT_AND: u8 = 0b100100;
@@ -112,6 +114,9 @@ pub const FMT_DOUBLE: u8 = 17;
 /// Returns [`None`] if the `funct` code is not supported.
 pub fn reg_width_by_funct(funct: u8) -> Option<RegWidth> {
     match funct {
+        // `syscall` does not have a register width associated with it,
+        // but is set for the purposes of a default signal value.
+        FUNCT_SYSCALL => Some(RegWidth::DoubleWord),
         FUNCT_ADD | FUNCT_SUB => Some(RegWidth::Word),
         FUNCT_AND | FUNCT_OR | FUNCT_SLT | FUNCT_SLTU => Some(RegWidth::DoubleWord),
         FUNCT_DADD | FUNCT_DSUB => Some(RegWidth::DoubleWord),

--- a/src/emulation_core/mips/control_signals.rs
+++ b/src/emulation_core/mips/control_signals.rs
@@ -386,7 +386,7 @@ pub mod floating_point {
     ///
     /// *Implementation note:* The bits set for the comparator are intended to match
     /// the bits used in the `cond` field of a `c.cond.fmt` instruction.
-    #[derive(Clone, Default, PartialEq)]
+    #[derive(Clone, Debug, Default, PartialEq)]
     pub enum FpuAluOp {
         #[default]
         /// `_0000` (0):
@@ -433,14 +433,14 @@ pub mod floating_point {
 
     impl FpuAluOp {
         /// Get the corresponding control signal given a function code.
-        pub fn from_function(function: u8) -> Self {
+        pub fn from_function(function: u8) -> Result<Self, String> {
             match function {
-                FUNCTION_C_EQ => Self::MultiplicationOrEqual,
-                FUNCTION_C_LT => Self::Slt,
-                FUNCTION_C_NGE => Self::Snge,
-                FUNCTION_C_LE => Self::Sle,
-                FUNCTION_C_NGT => Self::Sngt,
-                _ => panic!("Unsupported function code `{function}`"),
+                FUNCTION_C_EQ => Ok(Self::MultiplicationOrEqual),
+                FUNCTION_C_LT => Ok(Self::Slt),
+                FUNCTION_C_NGE => Ok(Self::Snge),
+                FUNCTION_C_LE => Ok(Self::Sle),
+                FUNCTION_C_NGT => Ok(Self::Sngt),
+                _ => Err(format!("Unsupported function code `{function}`")),
             }
         }
     }

--- a/src/emulation_core/mips/control_signals.rs
+++ b/src/emulation_core/mips/control_signals.rs
@@ -506,13 +506,11 @@ pub mod floating_point {
     impl FpuRegWidth {
         /// Get the corresponding [`FpuRegWidth`] control signal based on
         /// the `fmt` field in an instruction.
-        pub fn from_fmt(fmt: u8) -> Self {
+        pub fn from_fmt(fmt: u8) -> Result<Self, String> {
             match fmt {
-                FMT_SINGLE => Self::Word,
-                FMT_DOUBLE => Self::DoubleWord,
-                _ => {
-                    unimplemented!("`{}` is an invalid fmt value", fmt);
-                }
+                FMT_SINGLE => Ok(Self::Word),
+                FMT_DOUBLE => Ok(Self::DoubleWord),
+                _ => Err(format!("`{fmt}` is an invalid fmt value")),
             }
         }
     }

--- a/src/emulation_core/mips/coprocessor.rs
+++ b/src/emulation_core/mips/coprocessor.rs
@@ -159,7 +159,12 @@ impl MipsFpCoprocessor {
                             self.signals.fpu_branch = FpuBranch::NoBranch;
                             self.signals.fpu_mem_to_reg = FpuMemToReg::UseDataWrite;
                             self.signals.fpu_reg_dst = FpuRegDst::Reg3;
-                            self.signals.fpu_reg_width = FpuRegWidth::from_fmt(r.fmt);
+                            self.signals.fpu_reg_width = match FpuRegWidth::from_fmt(r.fmt) {
+                                Ok(width) => width,
+                                Err(message) => {
+                                    FpuRegWidth::default()
+                                }
+                            };
                             self.signals.fpu_reg_write = FpuRegWrite::YesWrite;
                         }
                         FUNCTION_SUB => {
@@ -171,7 +176,12 @@ impl MipsFpCoprocessor {
                             self.signals.fpu_branch = FpuBranch::NoBranch;
                             self.signals.fpu_mem_to_reg = FpuMemToReg::UseDataWrite;
                             self.signals.fpu_reg_dst = FpuRegDst::Reg3;
-                            self.signals.fpu_reg_width = FpuRegWidth::from_fmt(r.fmt);
+                            self.signals.fpu_reg_width = match FpuRegWidth::from_fmt(r.fmt) {
+                                Ok(width) => width,
+                                Err(message) => {
+                                    FpuRegWidth::default()
+                                }
+                            };
                             self.signals.fpu_reg_write = FpuRegWrite::YesWrite;
                         }
                         FUNCTION_MUL => {
@@ -183,7 +193,12 @@ impl MipsFpCoprocessor {
                             self.signals.fpu_branch = FpuBranch::NoBranch;
                             self.signals.fpu_mem_to_reg = FpuMemToReg::UseDataWrite;
                             self.signals.fpu_reg_dst = FpuRegDst::Reg3;
-                            self.signals.fpu_reg_width = FpuRegWidth::from_fmt(r.fmt);
+                            self.signals.fpu_reg_width = match FpuRegWidth::from_fmt(r.fmt) {
+                                Ok(width) => width,
+                                Err(message) => {
+                                    FpuRegWidth::default()
+                                }
+                            };
                             self.signals.fpu_reg_write = FpuRegWrite::YesWrite;
                         }
                         FUNCTION_DIV => {
@@ -195,7 +210,12 @@ impl MipsFpCoprocessor {
                             self.signals.fpu_branch = FpuBranch::NoBranch;
                             self.signals.fpu_mem_to_reg = FpuMemToReg::UseDataWrite;
                             self.signals.fpu_reg_dst = FpuRegDst::Reg3;
-                            self.signals.fpu_reg_width = FpuRegWidth::from_fmt(r.fmt);
+                            self.signals.fpu_reg_width = match FpuRegWidth::from_fmt(r.fmt) {
+                                Ok(width) => width,
+                                Err(message) => {
+                                    FpuRegWidth::default()
+                                }
+                            };
                             self.signals.fpu_reg_write = FpuRegWrite::YesWrite;
                         }
                         // Unrecognized format code. Perform no operation.
@@ -296,7 +316,12 @@ impl MipsFpCoprocessor {
                         }
                     },
                     fpu_branch: FpuBranch::NoBranch,
-                    fpu_reg_width: FpuRegWidth::from_fmt(c.fmt),
+                    fpu_reg_width: match FpuRegWidth::from_fmt(c.fmt) {
+                        Ok(width) => width,
+                        Err(message) => {
+                            FpuRegWidth::default()
+                        }
+                    },
                     fpu_reg_write: FpuRegWrite::NoWrite,
                     ..Default::default()
                 }

--- a/src/emulation_core/mips/coprocessor.rs
+++ b/src/emulation_core/mips/coprocessor.rs
@@ -13,6 +13,7 @@ pub struct MipsFpCoprocessor {
     instruction: Instruction,
     pub signals: FpuControlSignals,
     pub state: FpuState,
+    pub is_halted: bool,
 
     pub fpr: [u64; 32],
     pub condition_code: u64,
@@ -60,6 +61,11 @@ impl MipsFpCoprocessor {
 
     pub fn stage_writeback(&mut self) {
         self.register_write();
+    }
+
+    /// Handle an otherwise irrecoverable error within the datapath.
+    pub fn error(&mut self, _message: &str) {
+        self.is_halted = true;
     }
 
     /// Set the internally-stored copy of the current instruction. This effectively

--- a/src/emulation_core/mips/coprocessor.rs
+++ b/src/emulation_core/mips/coprocessor.rs
@@ -101,7 +101,10 @@ impl MipsFpCoprocessor {
                 self.state.function = c.function as u32;
             }
             // These types do not use the floating-point unit so they can be ignored.
-            Instruction::RType(_) | Instruction::IType(_) | Instruction::JType(_) => (),
+            Instruction::RType(_)
+            | Instruction::IType(_)
+            | Instruction::JType(_)
+            | Instruction::SyscallType(_) => (),
         }
     }
 
@@ -288,9 +291,10 @@ impl MipsFpCoprocessor {
                 }
             }
             // These types do not use the floating-point unit so they can be ignored.
-            Instruction::RType(_) | Instruction::IType(_) | Instruction::JType(_) => {
-                self.signals = FpuControlSignals::default()
-            }
+            Instruction::RType(_)
+            | Instruction::IType(_)
+            | Instruction::JType(_)
+            | Instruction::SyscallType(_) => self.signals = FpuControlSignals::default(),
         }
     }
 

--- a/src/emulation_core/mips/coprocessor.rs
+++ b/src/emulation_core/mips/coprocessor.rs
@@ -289,7 +289,12 @@ impl MipsFpCoprocessor {
                     cc: Cc::Cc0,
                     cc_write: CcWrite::YesWrite,
                     data_write: DataWrite::NoWrite,
-                    fpu_alu_op: FpuAluOp::from_function(c.function),
+                    fpu_alu_op: match FpuAluOp::from_function(c.function) {
+                        Ok(op) => op,
+                        Err(message) => {
+                            FpuAluOp::default()
+                        }
+                    },
                     fpu_branch: FpuBranch::NoBranch,
                     fpu_reg_width: FpuRegWidth::from_fmt(c.fmt),
                     fpu_reg_write: FpuRegWrite::NoWrite,

--- a/src/emulation_core/mips/coprocessor.rs
+++ b/src/emulation_core/mips/coprocessor.rs
@@ -73,7 +73,9 @@ impl MipsFpCoprocessor {
     /// does not fetch instructions.
     pub fn set_instruction(&mut self, instruction_bits: u32) {
         self.state.instruction = instruction_bits;
-        self.instruction = Instruction::from(self.state.instruction);
+        if let Ok(instruction) = Instruction::try_from(self.state.instruction) {
+            self.instruction = instruction;
+        }
     }
 
     /// Decode an instruction into its individual fields.

--- a/src/emulation_core/mips/datapath.rs
+++ b/src/emulation_core/mips/datapath.rs
@@ -67,7 +67,7 @@ pub struct MipsDatapath {
     ///
     /// This is set in the event of any `syscall` instruction. To unset this,
     /// [`Self::reset()`] should be used.
-    pub is_halted: bool,
+    is_halted: bool,
 }
 
 /// A collection of all the data lines and wires in the datapath.
@@ -242,6 +242,10 @@ impl Datapath for MipsDatapath {
 
     fn get_memory(&self) -> &Self::MemoryType {
         &self.memory
+    }
+
+    fn is_halted(&self) -> bool {
+        self.is_halted
     }
 
     fn reset(&mut self) {

--- a/src/emulation_core/mips/datapath.rs
+++ b/src/emulation_core/mips/datapath.rs
@@ -203,6 +203,11 @@ impl Datapath for MipsDatapath {
 
     fn execute_instruction(&mut self) {
         loop {
+            // If the FPU has halted, reflect this in the main unit.
+            if self.coprocessor.is_halted {
+                self.is_halted = true;
+            }
+
             // Stop early if the datapath has halted.
             if self.is_halted {
                 break;

--- a/src/emulation_core/mips/datapath.rs
+++ b/src/emulation_core/mips/datapath.rs
@@ -47,7 +47,7 @@ use super::instruction::*;
 use super::{coprocessor::MipsFpCoprocessor, memory::Memory, registers::GpRegisters};
 
 /// An implementation of a datapath for the MIPS64 ISA.
-#[derive(PartialEq, Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MipsDatapath {
     pub registers: GpRegisters,
     pub memory: Memory,
@@ -144,7 +144,7 @@ pub struct DatapathState {
 }
 
 /// The possible stages the datapath could be in during execution.
-#[derive(Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
 pub enum Stage {
     #[default]
     InstructionFetch,

--- a/src/emulation_core/mips/datapath.rs
+++ b/src/emulation_core/mips/datapath.rs
@@ -440,7 +440,12 @@ impl MipsDatapath {
 
     /// Decode an instruction into its individual fields.
     fn instruction_decode(&mut self) {
-        self.instruction = Instruction::from(self.state.instruction);
+        match Instruction::try_from(self.state.instruction) {
+            Ok(instruction) => self.instruction = instruction,
+            Err(message) => {
+                return;
+            }
+        }
 
         // Set the data lines based on the contents of the instruction.
         // Some lines will hold uninitialized values as a result.

--- a/src/emulation_core/mips/instruction.rs
+++ b/src/emulation_core/mips/instruction.rs
@@ -57,7 +57,7 @@ pub struct FpuRType {
     pub function: u8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FpuIType {
     pub op: u8,
     pub base: u8,
@@ -83,7 +83,7 @@ pub struct FpuIType {
 /// - sub: Operation subcode field for COP1 register immediate-mode instructions.
 /// - rt: CPU register - can be either source or destination.
 /// - fs: FPU register - can be either source or destination.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FpuRegImmType {
     pub op: u8,
     pub sub: u8,
@@ -91,7 +91,7 @@ pub struct FpuRegImmType {
     pub fs: u8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FpuCompareType {
     pub op: u8,
     pub fmt: u8,

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn app() -> Html {
     // the ability to access and change its contents be mutable.
     let datapath = use_state_eq(|| Rc::new(RefCell::new(MipsDatapath::default())));
 
-    // This is where code is assembled and loaded into the instruction core's memory.
+    // This is where code is assembled and loaded into the emulation core's memory.
     let on_assemble_clicked = {
         let text_model = Rc::clone(&text_model);
         let datapath = Rc::clone(&datapath);

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,7 +345,7 @@ pub fn SwimEditor(props: &SwimEditorProps) -> Html {
 }
 
 /**********************  "Console" Component **********************/
-#[derive(Properties, PartialEq)]
+#[derive(PartialEq, Properties)]
 pub struct Consoleprops {
     pub parsermsg: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn app() -> Html {
 
                 // Load the binary into the datapath's memory
                 (*datapath)
-                    .load_instructions(assembled)
+                    .initialize(assembled)
                     .expect("Memory could not be loaded");
                 //log!(datapath.memory.to_string());
                 trigger.force_update();

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn app() -> Html {
 
                 // parses through the code to assemble the binary
                 let (_, assembled) = parser(text_model.get_value());
-                // log!(JsValue::from_str(&datapath.registers.to_string()));
+
                 // Load the binary into the datapath's memory
                 (*datapath)
                     .load_instructions(assembled)
@@ -160,10 +160,6 @@ fn app() -> Html {
                         .into(),
                 );
                 (*datapath).execute_instruction();
-                // log!("These are the arrays after the push");
-                // log!(new_decor_array.at(0));
-                // log!(old_decor_array.at(0));
-                // log!(JsValue::from_str(&datapath.registers.to_string()));
                 trigger.force_update();
                 new_decor_array.pop(); // done with the highlight, prepare for the next one.
             },
@@ -208,10 +204,6 @@ fn app() -> Html {
                         .into(),
                 );
                 (*datapath).reset();
-                // log!("The handle should still be there, no highlight");
-                // log!(old_decor_array.at(0));
-                // log!(new_decor_array.at(0));
-                // log!(JsValue::from_str(&datapath.registers.to_string()));
                 trigger.force_update();
             },
             (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,8 +276,8 @@ fn app() -> Html {
                     // Top buttons
                     <div>
                         <button class="button" onclick={on_assemble_clicked}>{ "Assemble" }</button>
-                        <button class="button" onclick={on_execute_clicked}> { "Execute" }</button>
-                        <button class="button" onclick={on_execute_stage_clicked}> { "Execute Stage" }</button>
+                        <button class="button" onclick={on_execute_clicked} disabled={(*datapath).borrow().is_halted()}> { "Execute" }</button>
+                        <button class="button" onclick={on_execute_stage_clicked} disabled={(*datapath).borrow().is_halted()}> { "Execute Stage" }</button>
                         <button class="button" onclick={on_reset_clicked}>{ "Reset" }</button>
                         <input type="button" value="Load File" onclick={upload_clicked_callback} />
                         <input type="button" value="Save to Clipboard" onclick={on_clipboard_clicked} />

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,8 +85,8 @@ fn app() -> Html {
     // the ability to access and change its contents be mutable.
     let datapath = use_state_eq(|| Rc::new(RefCell::new(MipsDatapath::default())));
 
-    // This is where we take the code and run it through the emulation core.
-    let on_load_clicked = {
+    // This is where code is assembled and loaded into the instruction core's memory.
+    let on_assemble_clicked = {
         let text_model = Rc::clone(&text_model);
         let datapath = Rc::clone(&datapath);
         let trigger = use_force_update();
@@ -275,7 +275,7 @@ fn app() -> Html {
                 <div style="flex-basis: 70%; display: flex; flex-direction: column; align-items: stretch;">
                     // Top buttons
                     <div>
-                        <button class="button" onclick={on_load_clicked}>{ "Assemble" }</button>
+                        <button class="button" onclick={on_assemble_clicked}>{ "Assemble" }</button>
                         <button class="button" onclick={on_execute_clicked}> { "Execute" }</button>
                         <button class="button" onclick={on_execute_stage_clicked}> { "Execute Stage" }</button>
                         <button class="button" onclick={on_reset_clicked}>{ "Reset" }</button>

--- a/src/parser/parser_structs_and_enums.rs
+++ b/src/parser/parser_structs_and_enums.rs
@@ -1,7 +1,7 @@
 pub mod instruction_tokenization {
     use std::default::Default;
 
-    #[derive(Default, Debug, Clone, PartialEq, Eq)]
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
     ///Wrapper for all information gathered in the Parser/Assembler about the written program.
     pub struct ProgramInfo {
         pub monaco_line_info: Vec<MonacoLineInfo>,
@@ -11,14 +11,14 @@ pub mod instruction_tokenization {
         pub data: Vec<Data>,
     }
 
-    #[derive(Default, Debug, Clone, PartialEq, Eq)]
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
     pub struct MonacoLineInfo {
         pub mouse_hover_string: String,
         pub error_start_end_columns: Vec<(u32, u32)>,
     }
 
     ///A collection of all relevant information found about an instruction in the Parser/Assembler
-    #[derive(Default, Debug, Clone, PartialEq, Eq)]
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
     pub struct Instruction {
         pub operator: Token,
         pub operands: Vec<Token>,
@@ -30,7 +30,7 @@ pub mod instruction_tokenization {
     }
 
     ///A collection of all relevant information found about a variable in the Parser/Assembler
-    #[derive(Default, Debug, Clone, PartialEq, Eq)]
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
     pub struct Data {
         pub data_number: u32,
         pub line_number: u32,
@@ -40,27 +40,27 @@ pub mod instruction_tokenization {
         pub data_entries_and_values: Vec<(Token, u32)>,
     }
 
-    #[derive(Default, Debug, Clone, PartialEq, Eq)]
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
     pub struct Token {
         pub token_name: String,
         pub start_end_columns: (u32, u32),
         pub token_type: TokenType,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct Line {
         pub line_number: u32,
         pub tokens: Vec<Token>,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct Error {
         pub error_name: ErrorType,
         pub operand_number: Option<u8>,
         pub message: String,
     }
 
-    #[derive(Default, Debug, PartialEq, Eq, Clone)]
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
     pub enum TokenType {
         #[default]
         Unknown,
@@ -82,7 +82,7 @@ pub mod instruction_tokenization {
         Double,
     }
 
-    #[derive(Debug, PartialEq, Eq, Clone)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
     pub enum ErrorType {
         UnsupportedInstruction, //valid MIPS64 instruction that is not supported by SWIM
         UnrecognizedGPRegister, //Given string does not match GP Register names
@@ -117,7 +117,7 @@ pub mod instruction_tokenization {
     }
 
     //This enum is just for the read_register_function to determine which register type it should expect
-    #[derive(PartialEq, Eq)]
+    #[derive(Eq, PartialEq)]
     pub enum RegisterType {
         GeneralPurpose,
         FloatingPoint,

--- a/src/tests/emulation_core/mips.rs
+++ b/src/tests/emulation_core/mips.rs
@@ -2829,7 +2829,7 @@ pub mod syscall {
     fn halts_on_syscall() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        assert!(!datapath.is_halted);
+        assert!(!datapath.is_halted());
 
         // This program doubles the value in $t1 and stops.
 
@@ -2851,7 +2851,7 @@ pub mod syscall {
         }
 
         assert_eq!(datapath.registers.gpr[9], 10); // $t1
-        assert!(datapath.is_halted);
+        assert!(datapath.is_halted());
         Ok(())
     }
 }

--- a/src/tests/emulation_core/mips.rs
+++ b/src/tests/emulation_core/mips.rs
@@ -15,7 +15,7 @@ pub mod api {
         // Add instruction into emulation core memory.
         let instruction = String::from("ori $s0, $zero, 5");
         let (_, instruction_bits) = parser(instruction);
-        datapath.load_instructions(instruction_bits)?;
+        datapath.initialize(instruction_bits)?;
 
         datapath.execute_instruction();
 
@@ -38,16 +38,13 @@ pub mod api {
 pub mod add {
     use super::*;
     #[test]
-    fn add_register_to_itself() {
+    fn add_register_to_itself() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $t1 = $t1 + $t1
-        //                       R-type  t1    t1    t1  (shamt)  ADD
-        let instruction: u32 = 0b000000_01001_01001_01001_00000_100000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t1    t1    t1  (shamt)  ADD
+        let instructions: Vec<u32> = vec![0b000000_01001_01001_01001_00000_100000];
+        datapath.initialize(instructions)?;
 
         // Assume the register $t1 has the value 5.
         datapath.registers[GpRegisterType::T1] = 5;
@@ -56,19 +53,17 @@ pub mod add {
 
         // After the operation is finished, the register should be 10.
         assert_eq!(datapath.registers[GpRegisterType::T1], 10);
+        Ok(())
     }
 
     #[test]
-    fn add_register_to_another() {
+    fn add_register_to_another() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 + $s1
-        //                       R-type  s0    s1    s2  (shamt)  ADD
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_100000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  ADD
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_100000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 15; // $s0
         datapath.registers.gpr[17] = 40; // $s1
@@ -78,21 +73,19 @@ pub mod add {
         // Register $s2 should contain 55.
         let result = datapath.registers.gpr[18] as u32;
         assert_eq!(result, 55);
+        Ok(())
     }
 
     #[test]
     // This test attempts to write to register $zero. The datapath should
     // not overwrite this register, and remain with a value of 0.
-    fn add_to_register_zero() {
+    fn add_to_register_zero() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $zero = $t3 + $t3
-        //                       R-type  t3    t3    zero (shamt) ADD
-        let instruction: u32 = 0b000000_01011_01011_00000_00000_100000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t3    t3    zero (shamt) ADD
+        let instructions: Vec<u32> = vec![0b000000_01011_01011_00000_00000_100000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[11] = 1234; // $t3
 
@@ -100,6 +93,7 @@ pub mod add {
 
         // $zero should still contain 0.
         assert_eq!(datapath.registers.gpr[0], 0);
+        Ok(())
     }
 
     #[test]
@@ -107,16 +101,13 @@ pub mod add {
     // handled exceptions. Therefore, we would expect to see an updated value in
     // register T1, rather than having the register unmodified per the MIPS64v6
     // specification.
-    fn add_32_bit_with_overflow() {
+    fn add_32_bit_with_overflow() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $t1 = $t4 + $t4
-        //                       R-type  t4    t4    t1 (shamt) ADD
-        let instruction: u32 = 0b000000_01100_01100_01001_00000_100000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t4    t4    t1 (shamt) ADD
+        let instructions: Vec<u32> = vec![0b000000_01100_01100_01001_00000_100000];
+        datapath.initialize(instructions)?;
 
         // Assume register $t4 contains 2,454,267,026, a 32-bit integer.
         datapath.registers.gpr[12] = 0b10010010_01001001_00100100_10010010;
@@ -128,6 +119,7 @@ pub mod add {
         // should be truncated. Thus, we should expect the register to
         // contain 613,566,756, or 00100100_10010010_01001001_00100100 in binary.
         assert_eq!(datapath.registers.gpr[9], 613566756);
+        Ok(())
     }
 
     #[test]
@@ -135,16 +127,13 @@ pub mod add {
     // handled exceptions. Therefore, we would expect to see an updated value in
     // register T1, rather than having the register unmodified per the MIPS64v6
     // specification.
-    fn add_32_bit_with_overflow_sign_extend() {
+    fn add_32_bit_with_overflow_sign_extend() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $t1 = $t4 + $t4
-        //                       R-type  t4    t4    t1 (shamt) ADD
-        let instruction: u32 = 0b000000_01100_01100_01001_00000_100000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t4    t4    t1 (shamt) ADD
+        let instructions: Vec<u32> = vec![0b000000_01100_01100_01001_00000_100000];
+        datapath.initialize(instructions)?;
 
         // Assume register $t4 contains 3,528,008,850, a 32-bit integer.
         datapath.registers.gpr[12] = 0b11010010_01001001_00100100_10010010;
@@ -156,6 +145,7 @@ pub mod add {
         // should be truncated. Thus, we should expect the register to
         // contain 2,761,050,404, or 10100100_10010010_01001001_00100100 in binary.
         assert_eq!(datapath.registers.gpr[9] as u32, 2761050404);
+        Ok(())
     }
 }
 
@@ -163,16 +153,13 @@ pub mod sub {
     use super::*;
 
     #[test]
-    fn sub_positive_result() {
+    fn sub_positive_result() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s3 - $s2
-        //                       R-type  s3    s2    s2  (shamt) SUB
-        let instruction: u32 = 0b000000_10011_10010_10010_00000_100010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s3    s2    s2  (shamt) SUB
+        let instructions: Vec<u32> = vec![0b000000_10011_10010_10010_00000_100010];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[19] = 7; // $s3
         datapath.registers.gpr[18] = 3; // $s2
@@ -181,19 +168,17 @@ pub mod sub {
 
         // Register $s2 should contain 4, as 7 - 3 = 4.
         assert_eq!(datapath.registers.gpr[18], 4);
+        Ok(())
     }
 
     #[test]
-    fn sub_32_bit_negative_result() {
+    fn sub_32_bit_negative_result() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $s0 - $t0
-        //                       R-type  s0    t0    s0  (shamt) SUB
-        let instruction: u32 = 0b000000_10000_01000_10000_00000_100010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    t0    s0  (shamt) SUB
+        let instructions: Vec<u32> = vec![0b000000_10000_01000_10000_00000_100010];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 5; // $s0
         datapath.registers.gpr[8] = 20; // $t0
@@ -202,19 +187,17 @@ pub mod sub {
 
         // Register $s0 should contain -15, as 5 - 20 = -15.
         assert_eq!(datapath.registers.gpr[16] as i32, -15);
+        Ok(())
     }
 
     #[test]
-    fn sub_32_bit_underflow() {
+    fn sub_32_bit_underflow() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $s0 - $t0
-        //                       R-type  s0    t0    s0  (shamt) SUB
-        let instruction: u32 = 0b000000_10000_01000_10000_00000_100010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    t0    s0  (shamt) SUB
+        let instructions: Vec<u32> = vec![0b000000_10000_01000_10000_00000_100010];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 0; // $s0
         datapath.registers.gpr[8] = 1; // $t0
@@ -226,6 +209,7 @@ pub mod sub {
             datapath.registers.gpr[16] as u32,
             0b11111111_11111111_11111111_11111111
         );
+        Ok(())
     }
 }
 
@@ -233,16 +217,13 @@ pub mod mul {
     use super::*;
 
     #[test]
-    fn mul_positive_result() {
+    fn mul_positive_result() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s5 = $t7 * $t6
-        //                       R-type  t7    t6    s5    MUL   SOP30
-        let instruction: u32 = 0b000000_01111_01110_10101_00010_011000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t7    t6    s5    MUL   SOP30
+        let instructions: Vec<u32> = vec![0b000000_01111_01110_10101_00010_011000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[15] = 8; // $t7
         datapath.registers.gpr[14] = 95; // $t6
@@ -250,19 +231,17 @@ pub mod mul {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.gpr[21], 760); // $s5
+        Ok(())
     }
 
     #[test]
-    fn mul_32_bit_negative_result() {
+    fn mul_32_bit_negative_result() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s5 = $t7 * $t6
-        //                       R-type  t7    t6    s5    MUL   SOP30
-        let instruction: u32 = 0b000000_01111_01110_10101_00010_011000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t7    t6    s5    MUL   SOP30
+        let instructions: Vec<u32> = vec![0b000000_01111_01110_10101_00010_011000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[15] = 5; // $t7
         datapath.registers.gpr[14] = -5_i64 as u64; // $t6
@@ -270,19 +249,17 @@ pub mod mul {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.gpr[21] as i64, -25); // $s5
+        Ok(())
     }
 
     #[test]
-    fn mul_result_truncate() {
+    fn mul_result_truncate() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s4 = $t6 * $t5
-        //                       R-type  t6    t5    s4    MUL   SOP30
-        let instruction: u32 = 0b000000_01110_01101_10100_00010_011000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t6    t5    s4    MUL   SOP30
+        let instructions: Vec<u32> = vec![0b000000_01110_01101_10100_00010_011000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[14] = 731_564_544; // $t6
         datapath.registers.gpr[13] = 8; // $t5
@@ -296,6 +273,7 @@ pub mod mul {
             datapath.registers.gpr[20],
             0b01011100_11010110_01010000_00000000
         ); // $s5
+        Ok(())
     }
 }
 
@@ -303,16 +281,13 @@ pub mod div {
     use super::*;
 
     #[test]
-    fn div_positive_result() {
+    fn div_positive_result() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s4 = $t6 / $t5
-        //                       R-type  t6    t5    s4    DIV   SOP32
-        let instruction: u32 = 0b000000_01110_01101_10100_00010_011010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t6    t5    s4    DIV   SOP32
+        let instructions: Vec<u32> = vec![0b000000_01110_01101_10100_00010_011010];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[14] = 20; // $t6
         datapath.registers.gpr[13] = 2; // $t5
@@ -320,19 +295,17 @@ pub mod div {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.gpr[20], 10); // $s5
+        Ok(())
     }
 
     #[test]
-    fn div_negative_result() {
+    fn div_negative_result() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s4 = $t6 / $t5
-        //                       R-type  t6    t5    s4    DIV   SOP32
-        let instruction: u32 = 0b000000_01110_01101_10100_00010_011010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t6    t5    s4    DIV   SOP32
+        let instructions: Vec<u32> = vec![0b000000_01110_01101_10100_00010_011010];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[14] = 20; // $t6
         datapath.registers.gpr[13] = -5_i64 as u64; // $t5
@@ -340,6 +313,7 @@ pub mod div {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.gpr[20] as i64, -4); // $s5
+        Ok(())
     }
 }
 
@@ -347,35 +321,30 @@ pub mod or {
     use super::*;
 
     #[test]
-    fn or_register_to_itself() {
+    fn or_register_to_itself() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $t1 = $t1 & $t1
-        //                       R-type  t1    t1    t1  (shamt)  OR
-        let instruction: u32 = 0b000000_01001_01001_01001_00000_100101;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t1    t1    t1  (shamt)  OR
+        let instructions: Vec<u32> = vec![0b000000_01001_01001_01001_00000_100101];
+        datapath.initialize(instructions)?;
 
         // Assume the register $t1 has the value 5.
         datapath.registers[GpRegisterType::T1] = 0x5;
 
         datapath.execute_instruction();
         assert_eq!(datapath.registers[GpRegisterType::T1], 0x5);
+        Ok(())
     }
 
     #[test]
-    fn or_register_to_another16() {
+    fn or_register_to_another16() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 & $s1
-        //                       R-type  s0    s1    s2  (shamt)  OR
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_100101;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  OR
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_100101];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 0x1234; // $s0
         datapath.registers.gpr[17] = 0x4321; // $s1
@@ -385,19 +354,17 @@ pub mod or {
         // Register $s2 should contain 55.
         let result = datapath.registers.gpr[18];
         assert_eq!(result, 0x5335);
+        Ok(())
     }
 
     #[test]
-    fn or_register_to_another32() {
+    fn or_register_to_another32() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 & $s1
-        //                       R-type  s0    s1    s2  (shamt)  OR
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_100101;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  OR
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_100101];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 0x12341234; // $s0
         datapath.registers.gpr[17] = 0x43214321; // $s1
@@ -407,19 +374,17 @@ pub mod or {
         // Register $s2 should contain something...
         let result = datapath.registers.gpr[18];
         assert_eq!(result, 0x53355335);
+        Ok(())
     }
 
     #[test]
-    fn or_register_to_another64() {
+    fn or_register_to_another64() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 & $s1
-        //                       R-type  s0    s1    s2  (shamt)  OR
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_100101;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  OR
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_100101];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 0x1234123412341234; // $s0
         datapath.registers.gpr[17] = 0x4321432143214321; // $s1
@@ -429,21 +394,19 @@ pub mod or {
         // Register $s2 should contain something...
         let result = datapath.registers.gpr[18];
         assert_eq!(result, 0x5335533553355335);
+        Ok(())
     }
 
     #[test]
     // This test attempts to write to register $zero. The datapath should
     // not overwrite this register, and remain with a value of 0.
-    fn or_to_register_zero() {
+    fn or_to_register_zero() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $zero = $t3 & $t3
-        //                       R-type  t3    t3    zero (shamt) OR
-        let instruction: u32 = 0b000000_01011_01011_00000_00000_100101;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t3    t3    zero (shamt) OR
+        let instructions: Vec<u32> = vec![0b000000_01011_01011_00000_00000_100101];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[11] = 1234; // $t3
 
@@ -451,41 +414,37 @@ pub mod or {
 
         // $zero should still contain 0.
         assert_eq!(datapath.registers.gpr[0], 0);
+        Ok(())
     }
 }
 pub mod and {
     use super::*;
 
     #[test]
-    fn and_register_to_itself() {
+    fn and_register_to_itself() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $t1 = $t1 & $t1
-        //                       R-type  t1    t1    t1  (shamt)  AND
-        let instruction: u32 = 0b000000_01001_01001_01001_00000_100100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t1    t1    t1  (shamt)  AND
+        let instructions: Vec<u32> = vec![0b000000_01001_01001_01001_00000_100100];
+        datapath.initialize(instructions)?;
 
         // Assume the register $t1 has the value 5.
         datapath.registers[GpRegisterType::T1] = 0x5;
 
         datapath.execute_instruction();
         assert_eq!(datapath.registers[GpRegisterType::T1], 0x5);
+        Ok(())
     }
 
     #[test]
-    fn and_register_to_another16() {
+    fn and_register_to_another16() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 & $s1
-        //                       R-type  s0    s1    s2  (shamt)  AND
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_100100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  AND
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_100100];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 0x1234; // $s0
         datapath.registers.gpr[17] = 0x4321; // $s1
@@ -495,19 +454,17 @@ pub mod and {
         // Register $s2 should contain 55.
         let result = datapath.registers.gpr[18];
         assert_eq!(result, 0x0220);
+        Ok(())
     }
 
     #[test]
-    fn and_register_to_another32() {
+    fn and_register_to_another32() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 & $s1
-        //                       R-type  s0    s1    s2  (shamt)  AND
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_100100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  AND
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_100100];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 0x12341234; // $s0
         datapath.registers.gpr[17] = 0x43214321; // $s1
@@ -517,19 +474,17 @@ pub mod and {
         // Register $s2 should contain 55.
         let result = datapath.registers.gpr[18];
         assert_eq!(result, 0x02200220);
+        Ok(())
     }
 
     #[test]
-    fn and_register_to_another64() {
+    fn and_register_to_another64() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 & $s1
-        //                       R-type  s0    s1    s2  (shamt)  AND
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_100100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  AND
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_100100];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 0x1234123412341234; // $s0
         datapath.registers.gpr[17] = 0x4321432143214321; // $s1
@@ -539,21 +494,19 @@ pub mod and {
         // Register $s2 should contain 55.
         let result = datapath.registers.gpr[18];
         assert_eq!(result, 0x0220022002200220);
+        Ok(())
     }
 
     #[test]
     // This test attempts to write to register $zero. The datapath should
     // not overwrite this register, and remain with a value of 0.
-    fn and_to_register_zero() {
+    fn and_to_register_zero() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $zero = $t3 & $t3
-        //                       R-type  t3    t3    zero (shamt) AND
-        let instruction: u32 = 0b000000_01011_01011_00000_00000_100100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  t3    t3    zero (shamt) AND
+        let instructions: Vec<u32> = vec![0b000000_01011_01011_00000_00000_100100];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[11] = 1234; // $t3
 
@@ -561,6 +514,7 @@ pub mod and {
 
         // $zero should still contain 0.
         assert_eq!(datapath.registers.gpr[0], 0);
+        Ok(())
     }
 }
 
@@ -568,16 +522,13 @@ pub mod slt {
     use super::*;
 
     #[test]
-    fn easy_rs_less_than_rt_test() {
+    fn easy_rs_less_than_rt_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 < $s1
-        //                       R-type  s0    s1    s2  (shamt)  SLT
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_101010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  SLT
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_101010];
+        datapath.initialize(instructions)?;
 
         datapath.registers[GpRegisterType::S0] = 1;
         datapath.registers[GpRegisterType::S1] = 123;
@@ -585,19 +536,17 @@ pub mod slt {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S2], 1);
+        Ok(())
     }
 
     #[test]
-    fn easy_rs_greater_than_rt_test() {
+    fn easy_rs_greater_than_rt_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 < $s1
-        //                       R-type  s0    s1    s2  (shamt)  SLT
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_101010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  SLT
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_101010];
+        datapath.initialize(instructions)?;
 
         datapath.registers[GpRegisterType::S0] = 124;
         datapath.registers[GpRegisterType::S1] = 123;
@@ -605,19 +554,17 @@ pub mod slt {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S2], 0);
+        Ok(())
     }
 
     #[test]
-    fn easy_signed_test() {
+    fn easy_signed_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 < $s1
-        //                       R-type  s0    s1    s2  (shamt)  SLT
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_101010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  SLT
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_101010];
+        datapath.initialize(instructions)?;
 
         datapath.registers[GpRegisterType::S0] = -124_i64 as u64;
         datapath.registers[GpRegisterType::S1] = 123;
@@ -625,6 +572,7 @@ pub mod slt {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S2], 1);
+        Ok(())
     }
 }
 
@@ -632,16 +580,13 @@ pub mod sltu {
     use super::*;
 
     #[test]
-    fn easy_rs_less_than_rt_test() {
+    fn easy_rs_less_than_rt_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 < $s1
-        //                       R-type  s0    s1    s2  (shamt)  SLTU
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_101011;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  SLTU
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_101011];
+        datapath.initialize(instructions)?;
 
         datapath.registers[GpRegisterType::S0] = 1;
         datapath.registers[GpRegisterType::S1] = 123;
@@ -649,19 +594,17 @@ pub mod sltu {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S2], 1);
+        Ok(())
     }
 
     #[test]
-    fn easy_rs_greater_than_rt_test() {
+    fn easy_rs_greater_than_rt_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 < $s1
-        //                       R-type  s0    s1    s2  (shamt)  SLTU
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_101011;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  SLTU
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_101011];
+        datapath.initialize(instructions)?;
 
         datapath.registers[GpRegisterType::S0] = 124;
         datapath.registers[GpRegisterType::S1] = 123;
@@ -669,19 +612,17 @@ pub mod sltu {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S2], 0);
+        Ok(())
     }
 
     #[test]
-    fn easy_signed_test() {
+    fn easy_signed_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s2 = $s0 < $s1
-        //                       R-type  s0    s1    s2  (shamt)  SLTU
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_101011;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  R-type  s0    s1    s2  (shamt)  SLTU
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_101011];
+        datapath.initialize(instructions)?;
 
         datapath.registers[GpRegisterType::S0] = -124_i64 as u64;
         datapath.registers[GpRegisterType::S1] = 123;
@@ -689,39 +630,35 @@ pub mod sltu {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S2], 0);
+        Ok(())
     }
 }
 
 pub mod andi {
     use super::*;
     #[test]
-    fn and_immediate_with_zero() {
+    fn and_immediate_with_zero() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $zero & 12345
-        //                       andi    $zero  $s0   12345
-        let instruction: u32 = 0b001100_00000_10000_0011000000111001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  andi    $zero  $s0   12345
+        let instructions: Vec<u32> = vec![0b001100_00000_10000_0011000000111001];
+        datapath.initialize(instructions)?;
 
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.gpr[16], 0); // $s0
+        Ok(())
     }
 
     #[test]
-    fn andi_immediate_with_value() {
+    fn andi_immediate_with_value() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 & 12345
-        //                       andi     $t0   $s0   12345
-        let instruction: u32 = 0b001100_01000_10000_0011000000111001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  andi     $t0   $s0   12345
+        let instructions: Vec<u32> = vec![0b001100_01000_10000_0011000000111001];
+        datapath.initialize(instructions)?;
 
         // In binary: 00111010 11011110 01101000 10110001
         datapath.registers.gpr[8] = 987654321; // $t0
@@ -735,168 +672,150 @@ pub mod andi {
         //       8,241:  00000000 00000000 00100000 00110001
 
         assert_eq!(datapath.registers.gpr[16], 0x2031); // $s0
+        Ok(())
     }
 }
 
 pub mod addi_addiu {
     use super::*;
     #[test]
-    fn addi_simple_test() {
+    fn addi_simple_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x4
-        //                       addi    $t0   $s0          4
-        let instruction: u32 = 0b001000_01000_10000_0000000000000100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  addi    $t0   $s0          4
+        let instructions: Vec<u32> = vec![0b001000_01000_10000_0000000000000100];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 1;
         datapath.registers[GpRegisterType::S0] = 123;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S0], 5);
+        Ok(())
     }
 
     #[test]
-    fn addi_overflow_test() {
+    fn addi_overflow_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x1
-        //                       addi    $t0   $s0          1
-        let instruction: u32 = 0b001000_01000_10000_0000000000000100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  addi    $t0   $s0          1
+        let instructions: Vec<u32> = vec![0b001000_01000_10000_0000000000000100];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 0xffffffff;
         datapath.registers[GpRegisterType::S0] = 123;
         datapath.execute_instruction();
 
         // If there is an overflow on addi, $s0 should not change.
         assert_eq!(datapath.registers[GpRegisterType::S0], 123);
+        Ok(())
     }
 
     #[test]
-    fn addi_sign_extend_test() {
+    fn addi_sign_extend_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x1
-        //                       addi    $t0   $s0          1
-        let instruction: u32 = 0b001000_01000_10000_0000000000000001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  addi    $t0   $s0          1
+        let instructions: Vec<u32> = vec![0b001000_01000_10000_0000000000000001];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 0xfffffff1;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S0], 0xfffffffffffffff2);
+        Ok(())
     }
 
     #[test]
-    fn addi_sign_extend_test2() {
+    fn addi_sign_extend_test2() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x1
-        //                       addi    $t0   $s0          1
-        let instruction: u32 = 0b001000_01000_10000_0000000000000001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  addi    $t0   $s0          1
+        let instructions: Vec<u32> = vec![0b001000_01000_10000_0000000000000001];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 0xfffffffe;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S0], 0xffffffffffffffff);
+        Ok(())
     }
 
     #[test]
-    fn addiu_simple_test() {
+    fn addiu_simple_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x4
-        //                       addiu    $t0   $s0          4
-        let instruction: u32 = 0b001001_01000_10000_0000000000000100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  addiu    $t0   $s0          4
+        let instructions: Vec<u32> = vec![0b001001_01000_10000_0000000000000100];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 1;
         datapath.registers[GpRegisterType::S0] = 123;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S0], 5);
+        Ok(())
     }
 
     #[test]
-    fn addiu_overflow_test() {
+    fn addiu_overflow_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x4
-        //                       addiu    $t0   $s0          4
-        let instruction: u32 = 0b001001_01000_10000_0000000000000100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  addiu    $t0   $s0          4
+        let instructions: Vec<u32> = vec![0b001001_01000_10000_0000000000000100];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 0xffffffff;
         datapath.registers[GpRegisterType::S0] = 123;
         datapath.execute_instruction();
 
         // For the addiu instruction, $s0 would change on overflow, it would become 3.
         assert_eq!(datapath.registers[GpRegisterType::S0], 3);
+        Ok(())
     }
 
     #[test]
-    fn addiu_sign_extend_test() {
+    fn addiu_sign_extend_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x1
-        //                       addi    $t0   $s0          1
-        let instruction: u32 = 0b001000_01000_10000_0000000000000001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  addi    $t0   $s0          1
+        let instructions: Vec<u32> = vec![0b001000_01000_10000_0000000000000001];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 0xfffffff1;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S0], 0xfffffffffffffff2);
+        Ok(())
     }
 }
 
 pub mod daddi_and_daddiu {
     use super::*;
     #[test]
-    fn daddi_simple_test() {
+    fn daddi_simple_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x4
-        //                       daddi    $t0   $s0          4
-        let instruction: u32 = 0b011000_01000_10000_0000000000000100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  daddi    $t0   $s0          4
+        let instructions: Vec<u32> = vec![0b011000_01000_10000_0000000000000100];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 1;
         datapath.registers[GpRegisterType::S0] = 123;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S0], 5);
+        Ok(())
     }
 
     #[test]
-    fn daddi_overflow_test() {
+    fn daddi_overflow_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x1
-        //                       daddi    $t0   $s0          1
-        let instruction: u32 = 0b011000_01000_10000_0000000000000001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  daddi    $t0   $s0          1
+        let instructions: Vec<u32> = vec![0b011000_01000_10000_0000000000000001];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 0xffffffffffffffff;
         datapath.registers[GpRegisterType::S0] = 123;
         datapath.execute_instruction();
@@ -904,71 +823,63 @@ pub mod daddi_and_daddiu {
         // if there is an overflow, $s0 should not change.
         // For the addiu instruction, $s0 would change on overflow, it would become 3.
         assert_eq!(datapath.registers[GpRegisterType::S0], 123);
+        Ok(())
     }
 
     #[test]
-    fn daddi_sign_extend_test() {
+    fn daddi_sign_extend_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x1
-        //                       daddi    $t0   $s0          1
-        let instruction: u32 = 0b011000_01000_10000_0000000000000001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  daddi    $t0   $s0          1
+        let instructions: Vec<u32> = vec![0b011000_01000_10000_0000000000000001];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 0xfffffffffffffff1;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S0], 0xfffffffffffffff2);
+        Ok(())
     }
 
     #[test]
-    fn daddi_sign_extend_test2() {
+    fn daddi_sign_extend_test2() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x1
-        //                       daddi    $t0   $s0          1
-        let instruction: u32 = 0b011000_01000_10000_0000000000000001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  daddi    $t0   $s0          1
+        let instructions: Vec<u32> = vec![0b011000_01000_10000_0000000000000001];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 0xfffffffffffffffe;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S0], 0xffffffffffffffff);
+        Ok(())
     }
 
     #[test]
-    fn daddiu_simple_test() {
+    fn daddiu_simple_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x4
-        //                       daddiu    $t0   $s0          4
-        let instruction: u32 = 0b011001_01000_10000_0000000000000100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  daddiu    $t0   $s0          4
+        let instructions: Vec<u32> = vec![0b011001_01000_10000_0000000000000100];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 1;
         datapath.registers[GpRegisterType::S0] = 123;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S0], 5);
+        Ok(())
     }
 
     #[test]
-    fn daddiu_overflow_test() {
+    fn daddiu_overflow_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x4
-        //                       daddiu    $t0   $s0          4
-        let instruction: u32 = 0b011001_01000_10000_0000000000000100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  daddiu    $t0   $s0          4
+        let instructions: Vec<u32> = vec![0b011001_01000_10000_0000000000000100];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 0xffffffffffffffff;
         datapath.registers[GpRegisterType::S0] = 123;
         datapath.execute_instruction();
@@ -976,56 +887,50 @@ pub mod daddi_and_daddiu {
         // if there is an overflow, $s0 should not change.
         // For the addiu instruction, $s0 would change on overflow, it would become 3.
         assert_eq!(datapath.registers[GpRegisterType::S0], 3);
+        Ok(())
     }
 
     #[test]
-    fn daddiu_sign_extend_test() {
+    fn daddiu_sign_extend_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 + 0x1
-        //                       daddiu    $t0   $s0          1
-        let instruction: u32 = 0b011001_01000_10000_0000000000000001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store addi");
+        //                                  daddiu    $t0   $s0          1
+        let instructions: Vec<u32> = vec![0b011001_01000_10000_0000000000000001];
+        datapath.initialize(instructions)?;
         datapath.registers[GpRegisterType::T0] = 0xfffffffffffffff1;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers[GpRegisterType::S0], 0xfffffffffffffff2);
+        Ok(())
     }
 }
 
 pub mod ori {
     use super::*;
     #[test]
-    fn or_immediate_with_zero() {
+    fn or_immediate_with_zero() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $zero | 12345
-        //                       ori    $zero  $s0   12345
-        let instruction: u32 = 0b001101_00000_10000_0011000000111001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  ori    $zero  $s0   12345
+        let instructions: Vec<u32> = vec![0b001101_00000_10000_0011000000111001];
+        datapath.initialize(instructions)?;
 
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.gpr[16], 12345); // $s0
+        Ok(())
     }
 
     #[test]
-    fn or_immediate_with_value() {
+    fn or_immediate_with_value() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // $s0 = $t0 | 12345
-        //                       ori     $t0   $s0   12345
-        let instruction: u32 = 0b001101_01000_10000_0011000000111001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  ori     $t0   $s0   12345
+        let instructions: Vec<u32> = vec![0b001101_01000_10000_0011000000111001];
+        datapath.initialize(instructions)?;
 
         // In binary: 00111010 11011110 01101000 10110001
         datapath.registers.gpr[8] = 987654321; // $t0
@@ -1039,6 +944,7 @@ pub mod ori {
         // 987,658,425:  00111010 11011110 01111000 10111001
 
         assert_eq!(datapath.registers.gpr[16], 987658425); // $s0
+        Ok(())
     }
 }
 
@@ -1046,20 +952,16 @@ pub mod dadd_daddu {
     use super::*;
 
     #[test]
-    fn dadd_register_to_itself() {
+    fn dadd_register_to_itself() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // dadd rd, rs, rt
         // dadd $v0, $t5, $t5
         // GPR[2] <- GPR[13] + GPR[13]
-        //                      SPECIAL rs    rt    rd    0     DADD
-        //                              13    13    2
-        let instruction: u32 = 0b000000_01101_01101_00010_00000_101100;
-
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                 SPECIAL rs    rt    rd    0     DADD
+        //                                         13    13    2
+        let instructions: Vec<u32> = vec![0b000000_01101_01101_00010_00000_101100];
+        datapath.initialize(instructions)?;
 
         // Assume register $t5 contains 969,093,589,304, which is an integer
         // that takes up 39 bits.
@@ -1068,6 +970,7 @@ pub mod dadd_daddu {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.gpr[2], 1_938_187_178_608); // $v0
+        Ok(())
     }
 
     #[test]
@@ -1077,10 +980,10 @@ pub mod dadd_daddu {
         // daddu rd, rs, rt
         // daddu $s2, $s0, $s1
         // GPR[18] <- GPR[16] + GPR[17]
-        //                      SPECIAL rs    rt    rd    0     DADDU
-        //                              16    17    18
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_101101;
-        datapath.memory.store_word(0, instruction)?;
+        //                                 SPECIAL rs    rt    rd    0     DADDU
+        //                                         16    17    18
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_101101];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 1_069_193_590_294; // $s0
         datapath.registers.gpr[17] = 34_359_738_368; // $s1
@@ -1096,7 +999,7 @@ pub mod dsub_dsubu {
     use super::*;
 
     #[test]
-    fn dsub_registers_positive_result() {
+    fn dsub_registers_positive_result() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // dsub rd, rs, rt
@@ -1104,15 +1007,11 @@ pub mod dsub_dsubu {
         // GPR[rd] <- GPR[rs] - GPR[rt]
         // GPR[$s5] <- GPR[$s4] - GPR[$s3]
         // GPR[19] <- GPR[18] - GPR[17]
-        //                      SPECIAL rs    rt    rd    0     funct
-        //                              $s4   $s3   $s5         DSUB
-        //                              18    17    19
-        let instruction: u32 = 0b000000_10010_10001_10011_00000_101110;
-
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                 SPECIAL rs    rt    rd    0     funct
+        //                                         $s4   $s3   $s5         DSUB
+        //                                         18    17    19
+        let instructions: Vec<u32> = vec![0b000000_10010_10001_10011_00000_101110];
+        datapath.initialize(instructions)?;
 
         // Assume registers $s3 and $s4 contain numbers larger than 32 bits,
         // but smaller than 64 bits.
@@ -1122,6 +1021,7 @@ pub mod dsub_dsubu {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.gpr[19], 4_669_680_037_183_490); // $s5
+        Ok(())
     }
 
     #[test]
@@ -1131,10 +1031,10 @@ pub mod dsub_dsubu {
         // dsubu rd, rs, rt
         // dsubu $s2, $s0, $s1
         // GPR[18] <- GPR[16] - GPR[17]
-        //                      SPECIAL rs    rt    rd    0     DSUBU
-        //                              16    17    18
-        let instruction: u32 = 0b000000_10000_10001_10010_00000_101111;
-        datapath.memory.store_word(0, instruction)?;
+        //                                 SPECIAL rs    rt    rd    0     DSUBU
+        //                                         16    17    18
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00000_101111];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 92_975_612_771_919; // $s0
         datapath.registers.gpr[17] = 13_810_775_572_047; // $s1
@@ -1150,22 +1050,18 @@ pub mod dmul_dmulu {
     use super::*;
 
     #[test]
-    fn dmul_positive_result() {
+    fn dmul_positive_result() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // dmul rd, rs, rt
         // dmul $a0, $t8, $t9
         // dmul 4, 24, 25
         // GPR[rd] <- lo_doubleword(multiply.signed(GPR[rs] * GPR[rt]))
-        //                      opcode  rs    rt    rd          funct
-        //                      SPECIAL $t8   $t9   $a0   DMUL  SOP34
-        //                              24    25    4
-        let instruction: u32 = 0b000000_11000_11001_00100_00010_011100;
-
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                 opcode  rs    rt    rd          funct
+        //                                 SPECIAL $t8   $t9   $a0   DMUL  SOP34
+        //                                         24    25    4
+        let instructions: Vec<u32> = vec![0b000000_11000_11001_00100_00010_011100];
+        datapath.initialize(instructions)?;
 
         // Assume register $t8 contains a number larger than 32 bits,
         // but smaller than 64 bits.
@@ -1175,25 +1071,22 @@ pub mod dmul_dmulu {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.gpr[4], 29_305_181_415_085); // $a0
+        Ok(())
     }
 
     #[test]
-    fn dmul_negative_result() {
+    fn dmul_negative_result() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // dmul rd, rs, rt
         // dmul $s7, $t7, $t6
         // dmul 23, 15, 14
         // GPR[rd] <- lo_doubleword(multiply.signed(GPR[rs] * GPR[rt]))
-        //                      opcode  rs    rt    rd          funct
-        //                      SPECIAL $t7   $t6   $s7   DMUL  SOP34
-        //                              15    14    23
-        let instruction: u32 = 0b000000_01111_01110_10111_00010_011100;
-
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                 opcode  rs    rt    rd          funct
+        //                                 SPECIAL $t7   $t6   $s7   DMUL  SOP34
+        //                                         15    14    23
+        let instructions: Vec<u32> = vec![0b000000_01111_01110_10111_00010_011100];
+        datapath.initialize(instructions)?;
 
         // Assume register $t7 contains a number larger than 32 bits,
         // but smaller than 64 bits.
@@ -1203,25 +1096,22 @@ pub mod dmul_dmulu {
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.gpr[23] as i64, -6_901_771_906_582_095); // $s7
+        Ok(())
     }
 
     #[test]
-    fn dmul_result_truncate() {
+    fn dmul_result_truncate() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // dmul rd, rs, rt
         // dmul $s2, $s4, $s3
         // dmul 18, 20, 19
         // GPR[rd] <- lo_doubleword(multiply.signed(GPR[rs] * GPR[rt]))
-        //                      opcode  rs    rt    rd          funct
-        //                      SPECIAL $s4   $s3   $s2   DMUL  SOP34
-        //                              20    19    18
-        let instruction: u32 = 0b000000_10100_10011_10010_00010_011100;
-
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                 opcode  rs    rt    rd          funct
+        //                                 SPECIAL $s4   $s3   $s2   DMUL  SOP34
+        //                                         20    19    18
+        let instructions: Vec<u32> = vec![0b000000_10100_10011_10010_00010_011100];
+        datapath.initialize(instructions)?;
 
         // Assume registers $s4 and $s3 contain numbers larger than 32 bits,
         // but smaller than 64 bits.
@@ -1235,6 +1125,7 @@ pub mod dmul_dmulu {
         // (110 11000111 10110001 01001110 10000100 [00110100 01101011 00001011 00010110 11011010 00010011 11111000 11111000])
         // The result should instead truncate to the lower 64 bits.
         assert_eq!(datapath.registers.gpr[18], 3_777_124_905_256_220_920); // $s2
+        Ok(())
     }
 
     #[test]
@@ -1245,11 +1136,11 @@ pub mod dmul_dmulu {
         // dmulu $s2, $s0, $s1
         // dmulu 18, 16, 17
         // GPR[rd] <- lo_doubleword(multiply.unsigned(GPR[rs] * GPR[rt]))
-        //                      opcode  rs    rt    rd          funct
-        //                      SPECIAL $s0   $s1   $s2   DMULU SOP35
-        //                              16    17    18
-        let instruction: u32 = 0b000000_10000_10001_10010_00010_011101;
-        datapath.memory.store_word(0, instruction)?;
+        //                                 opcode  rs    rt    rd          funct
+        //                                 SPECIAL $s0   $s1   $s2   DMULU SOP35
+        //                                         16    17    18
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00010_011101];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 17_592_186_044_416; // $s0
         datapath.registers.gpr[17] = 1_000; // $s1
@@ -1265,22 +1156,19 @@ pub mod ddiv_ddivu {
     use super::*;
 
     #[test]
-    fn ddiv_positive_result() {
+    fn ddiv_positive_result() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // ddiv rd, rs, rt
         // ddiv $s0, $s1, $s2
         // ddiv 16, 17, 18
         // GPR[rd] <- divide.signed(GPR[rs], GPR[rt])
-        //                      opcode  rs    rt    rd          funct
-        //                      SPECIAL $s1   $s2   $s0   DDIV  SOP36
-        //                              17    18    16
-        let instruction: u32 = 0b000000_10001_10010_10000_00010_011110;
+        //                                 opcode  rs    rt    rd          funct
+        //                                 SPECIAL $s1   $s2   $s0   DDIV  SOP36
+        //                                         17    18    16
+        let instructions: Vec<u32> = vec![0b000000_10001_10010_10000_00010_011110];
 
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        datapath.initialize(instructions)?;
 
         // Assume register $s1 contains a number larger than 32 bits,
         // but smaller than 64 bits.
@@ -1292,25 +1180,23 @@ pub mod ddiv_ddivu {
         // While the actual result is 183,437,790,170.285714....
         // the decimal portion is truncated.
         assert_eq!(datapath.registers.gpr[16], 183_437_790_170); // $s0
+        Ok(())
     }
 
     #[test]
-    fn ddiv_negative_result() {
+    fn ddiv_negative_result() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // ddiv rd, rs, rt
         // ddiv $a3, $a2, $a1
         // ddiv 7, 6, 5
         // GPR[rd] <- divide.signed(GPR[rs], GPR[rt])
-        //                      opcode  rs    rt    rd          funct
-        //                      SPECIAL $a2   $a1   $a3   DDIV  SOP36
-        //                              6     5     7
-        let instruction: u32 = 0b000000_00110_00101_00111_00010_011110;
+        //                                 opcode  rs    rt    rd          funct
+        //                                 SPECIAL $a2   $a1   $a3   DDIV  SOP36
+        //                                         6     5     7
+        let instructions: Vec<u32> = vec![0b000000_00110_00101_00111_00010_011110];
 
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        datapath.initialize(instructions)?;
 
         // Assume register $a2 contains a number larger than 32 bits,
         // but smaller than 64 bits.
@@ -1322,6 +1208,7 @@ pub mod ddiv_ddivu {
         // While the actual result is -50,775,223,724,555,519.333333....
         // the decimal portion is truncated.
         assert_eq!(datapath.registers.gpr[7] as i64, -50_775_223_724_555_519); // $a3
+        Ok(())
     }
 
     #[test]
@@ -1332,12 +1219,12 @@ pub mod ddiv_ddivu {
         // ddivu $s2, $s0, $s1
         // ddivu 18, 16, 17
         // GPR[rd] <- divide.unsigned(GPR[rs], GPR[rt])
-        //                      opcode  rs    rt    rd          funct
-        //                      SPECIAL $s0   $s1   $s2   DDIVU SOP37
-        //                              16    17    18
-        let instruction: u32 = 0b000000_10000_10001_10010_00010_011111;
+        //                                 opcode  rs    rt    rd          funct
+        //                                 SPECIAL $s0   $s1   $s2   DDIVU SOP37
+        //                                         16    17    18
+        let instructions: Vec<u32> = vec![0b000000_10000_10001_10010_00010_011111];
 
-        datapath.memory.store_word(0, instruction)?;
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 10_213_202_487_240; // $s0
         datapath.registers.gpr[17] = 11; // $s1
@@ -1360,10 +1247,10 @@ pub mod dahi_dati {
         // dahi $a0, 1
         // GPR[rs] <- GPR[rs] + sign_extend(immediate << 32)
         // GPR[4] <- GPR[4] + sign_extend(1 << 32)
-        //                       op     rs    rt     immediate
-        //                       REGIMM $a0   DAHI   1
-        let instruction: u32 = 0b000001_00100_00110_0000000000000001;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  op     rs    rt     immediate
+        //                                  REGIMM $a0   DAHI   1
+        let instructions: Vec<u32> = vec![0b000001_00100_00110_0000000000000001];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[4] = 0xABCD; // $a0
 
@@ -1382,10 +1269,10 @@ pub mod dahi_dati {
         // dati $a1, 1
         // GPR[rs] <- GPR[rs] + sign_extend(immediate << 48)
         // GPR[5] <- GPR[5] + sign_extend(1 << 48)
-        //                       op     rs    rt     immediate
-        //                       REGIMM $a1   DATI   1
-        let instruction: u32 = 0b000001_00101_11110_0000000000000001;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  op     rs    rt     immediate
+        //                                  REGIMM $a1   DATI   1
+        let instructions: Vec<u32> = vec![0b000001_00101_11110_0000000000000001];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[5] = 0xABCD; // $a1
 
@@ -1400,115 +1287,93 @@ pub mod dahi_dati {
 pub mod load_word {
     use super::*;
     #[test]
-    fn lw_zero_offset_test() {
+    fn lw_zero_offset_test() -> Result<(), String> {
         // for this test the lw instruction will load itself from
         // memory
         let mut datapath = MipsDatapath::default();
 
-        //                        lw     $t0   $s0      offset = 0
-        let instruction: u32 = 0b100011_01000_10000_0000000000000000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  lw     $t0   $s0      offset = 0
+        let instructions: Vec<u32> = vec![0b100011_01000_10000_0000000000000000];
+        datapath.initialize(instructions.clone())?;
         datapath.execute_instruction();
-        assert_eq!(datapath.registers.gpr[16], instruction as u64);
+        assert_eq!(datapath.registers.gpr[16], instructions[0] as u64);
+        Ok(())
     }
 
     #[test]
-    fn lw_offset_at_4_test() {
+    fn lw_offset_at_4_test() -> Result<(), String> {
         // For this test the lw instruction will load 0x4 from memory
         // by using the offset address plus zero
         let mut datapath = MipsDatapath::default();
 
-        //                        lw     $t0   $s0      offset = 4
-        let instruction: u32 = 0b100011_01000_10000_0000000000000100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  lw     $t0   $s0      offset = 4
+        let instructions: Vec<u32> = vec![0b100011_01000_10000_0000000000000100];
+        datapath.initialize(instructions)?;
 
         // place data at address
-        datapath
-            .memory
-            .store_word(0b100, 0x10000)
-            .expect("failed to store test data");
+        datapath.memory.store_word(0b100, 0x10000)?;
 
         datapath.registers.gpr[8] = 0;
         datapath.execute_instruction();
         assert_eq!(datapath.registers.gpr[16], 0x10000);
+        Ok(())
     }
 
     #[test]
-    fn lw_gpr_8_at_4_offset_at_0_test() {
+    fn lw_gpr_8_at_4_offset_at_0_test() -> Result<(), String> {
         // for this test the lw instruction will load 0x4 from memory
         // by using (offset = 0) + (gpr[8] = 4)
         let mut datapath = MipsDatapath::default();
 
-        //                        lw     $t0   $s0      offset = 0
-        let instruction: u32 = 0b100011_01000_10000_0000000000000000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  lw     $t0   $s0      offset = 0
+        let instructions: Vec<u32> = vec![0b100011_01000_10000_0000000000000000];
+        datapath.initialize(instructions)?;
 
         // place data at address
-        datapath
-            .memory
-            .store_word(0b100, 0x10000)
-            .expect("failed to store test data");
+        datapath.memory.store_word(0b100, 0x10000)?;
 
         datapath.registers.gpr[8] = 4;
         datapath.execute_instruction();
         assert_eq!(datapath.registers.gpr[16], 0x10000);
+        Ok(())
     }
 
     #[test]
-    fn lw_gpr_8_at_4_offset_at_4_test() {
+    fn lw_gpr_8_at_4_offset_at_4_test() -> Result<(), String> {
         // for this test the lw instruction will load 0x8 from memory
         // by adding the offset to gpr[8]
         let mut datapath = MipsDatapath::default();
 
-        //                        lw     $t0   $s0      offset = 0
-        let instruction: u32 = 0b100011_01000_10000_0000000000000100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  lw     $t0   $s0      offset = 0
+        let instructions: Vec<u32> = vec![0b100011_01000_10000_0000000000000100];
+        datapath.initialize(instructions)?;
 
         // place data at address
-        datapath
-            .memory
-            .store_word(0b1000, 0x10000)
-            .expect("failed to store test data");
+        datapath.memory.store_word(0b1000, 0x10000)?;
 
         datapath.registers.gpr[8] = 4;
         datapath.execute_instruction();
         assert_eq!(datapath.registers.gpr[16], 0x10000);
+        Ok(())
     }
 
     #[test]
-    fn lw_gpr_8_at_12_offset_at_neg_4_test() {
+    fn lw_gpr_8_at_12_offset_at_neg_4_test() -> Result<(), String> {
         // for this test the lw instruction will load 0x8 from memory
         // by adding the offset to gpr[8]
         let mut datapath = MipsDatapath::default();
 
-        //                        lw     $t0   $s0      offset = 0
-        let instruction: u32 = 0b100011_01000_10000_1111111111111100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  lw     $t0   $s0      offset = 0
+        let instructions: Vec<u32> = vec![0b100011_01000_10000_1111111111111100];
+        datapath.initialize(instructions)?;
 
         // place data at address
-        datapath
-            .memory
-            .store_word(0b1000, 0x10000)
-            .expect("failed to store test data");
+        datapath.memory.store_word(0b1000, 0x10000)?;
 
         datapath.registers.gpr[8] = 12;
         datapath.execute_instruction();
         assert_eq!(datapath.registers.gpr[16], 0x10000);
+        Ok(())
     }
 }
 
@@ -1516,122 +1381,98 @@ pub mod load_upper_imm {
     use super::*;
 
     #[test]
-    fn basic_load_upper_imm_test() {
+    fn basic_load_upper_imm_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        //                        lui    $t0   $s0      offset = 42
-        let instruction: u32 = 0b001111_01000_10000_0010101010101010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  lui    $t0   $s0      offset = 42
+        let instructions: Vec<u32> = vec![0b001111_01000_10000_0010101010101010];
+        datapath.initialize(instructions)?;
         datapath.execute_instruction();
 
         let t = datapath.registers[GpRegisterType::S0];
         assert_eq!(t, 0x2aaa_0000);
+        Ok(())
     }
 
     #[test]
-    fn sign_extend_load_upper_imm_test() {
+    fn sign_extend_load_upper_imm_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        //                        lui    $t0   $s0      offset = 42
-        let instruction: u32 = 0b001111_01000_10000_1010101010101010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  lui    $t0   $s0      offset = 42
+        let instructions: Vec<u32> = vec![0b001111_01000_10000_1010101010101010];
+        datapath.initialize(instructions)?;
         datapath.execute_instruction();
 
         let t = datapath.registers[GpRegisterType::S0];
         assert_eq!(t, 0xffff_ffff_aaaa_0000);
+        Ok(())
     }
 }
 pub mod store_word {
     use super::*;
     #[test]
-    fn sw_zero_offset_test() {
+    fn sw_zero_offset_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        //                        lw     $t0   $s0      offset = 0
-        let instruction: u32 = 0b101011_01000_10000_0000000000000000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  sw     $t0   $s0      offset = 0
+        let instructions: Vec<u32> = vec![0b101011_01000_10000_0000000000000000];
+        datapath.initialize(instructions)?;
         datapath.execute_instruction();
 
-        let t = datapath
-            .memory
-            .load_word(0)
-            .expect("Could not load from memory");
+        let t = datapath.memory.load_word(0)?;
         assert_eq!(t, 0);
+        Ok(())
     }
 
     #[test]
-    fn sw_offset_at_4_test() {
+    fn sw_offset_at_4_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        //                        sw     $t0   $s0      offset = 4
-        let instruction: u32 = 0b101011_01000_10000_0000000000000100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  sw     $t0   $s0      offset = 4
+        let instructions: Vec<u32> = vec![0b101011_01000_10000_0000000000000100];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[8] = 0;
         datapath.registers.gpr[16] = 0xff;
         datapath.execute_instruction();
 
-        let t = datapath
-            .memory
-            .load_word(4)
-            .expect("Could not load from memory");
+        let t = datapath.memory.load_word(4)?;
         assert_eq!(t, 0xff);
+        Ok(())
     }
 
     #[test]
-    fn lw_gpr_8_at_4_offset_at_4_test() {
+    fn lw_gpr_8_at_4_offset_at_4_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        //                        sw     $t0   $s0      offset = 4
-        let instruction: u32 = 0b101011_01000_10000_0000000000000100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  sw     $t0   $s0      offset = 4
+        let instructions: Vec<u32> = vec![0b101011_01000_10000_0000000000000100];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[8] = 4;
         datapath.registers.gpr[16] = 0xff;
         datapath.execute_instruction();
 
-        let t = datapath
-            .memory
-            .load_word(8)
-            .expect("Could not load from memory");
+        let t = datapath.memory.load_word(8)?;
         assert_eq!(t, 0xff);
+        Ok(())
     }
 
     #[test]
-    fn lw_gpr_8_at_4_offset_at_neg_4_test() {
+    fn lw_gpr_8_at_4_offset_at_neg_4_test() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        //                        sw     $t0   $s0      offset = -4
-        let instruction: u32 = 0b101011_01000_10000_1111111111111100;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  sw     $t0   $s0      offset = -4
+        let instructions: Vec<u32> = vec![0b101011_01000_10000_1111111111111100];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[8] = 12;
         datapath.registers.gpr[16] = 0xff;
         datapath.execute_instruction();
 
-        let t = datapath
-            .memory
-            .load_word(8)
-            .expect("Could not load from memory");
+        let t = datapath.memory.load_word(8)?;
         assert_eq!(t, 0xff);
+        Ok(())
     }
 }
 
@@ -1640,19 +1481,16 @@ pub mod coprocessor {
     use crate::emulation_core::mips::datapath::MipsDatapath;
 
     #[test]
-    pub fn add_float_single_precision() {
+    pub fn add_float_single_precision() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // add.s fd, fs, ft
         // add.s $f2, $f1, $f0
         // FPR[2] = FPR[1] + FPR[0]
-        //                       COP1   fmt   ft    fs    fd    function
-        //                              s     $f0   $f1   $f2   ADD
-        let instruction: u32 = 0b010001_10000_00000_00001_00010_000000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  COP1   fmt   ft    fs    fd    function
+        //                                         s     $f0   $f1   $f2   ADD
+        let instructions: Vec<u32> = vec![0b010001_10000_00000_00001_00010_000000];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[0] = f32::to_bits(0.25f32) as u64;
         datapath.coprocessor.fpr[1] = f32::to_bits(0.5f32) as u64;
@@ -1662,22 +1500,20 @@ pub mod coprocessor {
         // The result should be 0.75, represented in a 32-bit value as per the
         // IEEE 754 single-precision floating-point specification.
         assert_eq!(f32::from_bits(datapath.coprocessor.fpr[2] as u32), 0.75);
+        Ok(())
     }
 
     #[test]
-    pub fn add_float_double_precision() {
+    pub fn add_float_double_precision() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // add.d fd, fs, ft
         // add.d $f2, $f1, $f0
         // FPR[2] = FPR[1] + FPR[0]
-        //                       COP1   fmt   ft    fs    fd    function
-        //                              d     $f0   $f1   $f2   ADD
-        let instruction: u32 = 0b010001_10001_00000_00001_00010_000000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  COP1   fmt   ft    fs    fd    function
+        //                                         d     $f0   $f1   $f2   ADD
+        let instructions: Vec<u32> = vec![0b010001_10001_00000_00001_00010_000000];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[0] = f64::to_bits(123.125);
         datapath.coprocessor.fpr[1] = f64::to_bits(0.5);
@@ -1687,23 +1523,21 @@ pub mod coprocessor {
         // The result should be 123.625, represented in a 64-bit value as per the
         // IEEE 754 double-precision floating-point specification.
         assert_eq!(f64::from_bits(datapath.coprocessor.fpr[2]), 123.625);
+        Ok(())
     }
 
     #[test]
-    pub fn sub_float_single_precision() {
+    pub fn sub_float_single_precision() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // sub.s fd, fs, ft
         // sub.s $f2, $f1, $f0
         // FPR[fd] = FPR[fs] - FPR[ft]
         // FPR[2] = FPR[1] - FPR[0]
-        //                       COP1   fmt   ft    fs    fd    function
-        //                              s     $f0   $f1   $f2   SUB
-        let instruction: u32 = 0b010001_10000_00000_00001_00010_000001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  COP1   fmt   ft    fs    fd    function
+        //                                         s     $f0   $f1   $f2   SUB
+        let instructions: Vec<u32> = vec![0b010001_10000_00000_00001_00010_000001];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[0] = f32::to_bits(5.625f32) as u64;
         datapath.coprocessor.fpr[1] = f32::to_bits(3.125f32) as u64;
@@ -1711,23 +1545,21 @@ pub mod coprocessor {
         datapath.execute_instruction();
 
         assert_eq!(f32::from_bits(datapath.coprocessor.fpr[2] as u32), -2.5);
+        Ok(())
     }
 
     #[test]
-    pub fn sub_float_double_precision() {
+    pub fn sub_float_double_precision() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // sub.d fd, fs, ft
         // sub.d $f2, $f1, $f0
         // FPR[fd] = FPR[fs] - FPR[ft]
         // FPR[2] = FPR[1] - FPR[0]
-        //                       COP1   fmt   ft    fs    fd    function
-        //                              d     $f0   $f1   $f2   SUB
-        let instruction: u32 = 0b010001_10001_00000_00001_00010_000001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  COP1   fmt   ft    fs    fd    function
+        //                                         d     $f0   $f1   $f2   SUB
+        let instructions: Vec<u32> = vec![0b010001_10001_00000_00001_00010_000001];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[0] = f64::to_bits(438.125);
         datapath.coprocessor.fpr[1] = f64::to_bits(98765.5);
@@ -1735,23 +1567,21 @@ pub mod coprocessor {
         datapath.execute_instruction();
 
         assert_eq!(f64::from_bits(datapath.coprocessor.fpr[2]), 98327.375);
+        Ok(())
     }
 
     #[test]
-    pub fn mul_float_single_precision() {
+    pub fn mul_float_single_precision() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // mul.s fd, fs, ft
         // mul.s $f9, $f5, $f4
         // FPR[fd] = FPR[fs] * FPR[ft]
         // FPR[9] = FPR[5] * FPR[4]
-        //                       COP1   fmt   ft    fs    fd    function
-        //                              s     $f4   $f5   $f9   MUL
-        let instruction: u32 = 0b010001_10000_00100_00101_01001_000010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  COP1   fmt   ft    fs    fd    function
+        //                                         s     $f4   $f5   $f9   MUL
+        let instructions: Vec<u32> = vec![0b010001_10000_00100_00101_01001_000010];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[5] = f32::to_bits(24.5f32) as u64;
         datapath.coprocessor.fpr[4] = f32::to_bits(0.5f32) as u64;
@@ -1759,23 +1589,21 @@ pub mod coprocessor {
         datapath.execute_instruction();
 
         assert_eq!(f32::from_bits(datapath.coprocessor.fpr[9] as u32), 12.25f32);
+        Ok(())
     }
 
     #[test]
-    pub fn mul_float_double_precision() {
+    pub fn mul_float_double_precision() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // mul.d fd, fs, ft
         // mul.d $f4, $f6, $f9
         // FPR[fd] = FPR[fs] * FPR[ft]
         // FPR[4] = FPR[6] * FPR[9]
-        //                       COP1   fmt   ft    fs    fd    function
-        //                              d     $f9   $f6   $f4   MUL
-        let instruction: u32 = 0b010001_10001_01001_00110_00100_000010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  COP1   fmt   ft    fs    fd    function
+        //                                         d     $f9   $f6   $f4   MUL
+        let instructions: Vec<u32> = vec![0b010001_10001_01001_00110_00100_000010];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[6] = f64::to_bits(-150.0625);
         datapath.coprocessor.fpr[9] = f64::to_bits(9.5);
@@ -1783,23 +1611,21 @@ pub mod coprocessor {
         datapath.execute_instruction();
 
         assert_eq!(f64::from_bits(datapath.coprocessor.fpr[4]), -1425.59375);
+        Ok(())
     }
 
     #[test]
-    pub fn div_float_single_precision() {
+    pub fn div_float_single_precision() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // div.s fd, fs, ft
         // div.s $f15, $f16, $f17
         // FPR[fd] = FPR[fs] / FPR[ft]
         // FPR[15] = FPR[16] / FPR[17]
-        //                       COP1   fmt   ft    fs    fd    function
-        //                              s     $f17  $f16  $f15  DIV
-        let instruction: u32 = 0b010001_10000_10001_10000_01111_000011;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  COP1   fmt   ft    fs    fd    function
+        //                                         s     $f17  $f16  $f15  DIV
+        let instructions: Vec<u32> = vec![0b010001_10000_10001_10000_01111_000011];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[16] = f32::to_bits(901f32) as u64;
         datapath.coprocessor.fpr[17] = f32::to_bits(2f32) as u64;
@@ -1810,23 +1636,21 @@ pub mod coprocessor {
             f32::from_bits(datapath.coprocessor.fpr[15] as u32),
             450.5f32
         );
+        Ok(())
     }
 
     #[test]
-    pub fn div_float_double_precision() {
+    pub fn div_float_double_precision() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // div.d fd, fs, ft
         // div.d $f1, $f10, $f20
         // FPR[fd] = FPR[fs] / FPR[ft]
         // FPR[1] = FPR[10] / FPR[20]
-        //                       COP1   fmt   ft    fs    fd    function
-        //                              d     $f20  $f10  $f1   DIV
-        let instruction: u32 = 0b010001_10001_10100_01010_00001_000011;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  COP1   fmt   ft    fs    fd    function
+        //                                         d     $f20  $f10  $f1   DIV
+        let instructions: Vec<u32> = vec![0b010001_10001_10100_01010_00001_000011];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[10] = f64::to_bits(95405.375);
         datapath.coprocessor.fpr[20] = f64::to_bits(2.0);
@@ -1834,23 +1658,21 @@ pub mod coprocessor {
         datapath.execute_instruction();
 
         assert_eq!(f64::from_bits(datapath.coprocessor.fpr[1]), 47702.6875);
+        Ok(())
     }
 
     #[test]
-    pub fn swc1_basic_store_no_offset() {
+    pub fn swc1_basic_store_no_offset() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // swc1 ft, offset(base)
         // swc1 $f3, 0($s1)
         // memory[GPR[base] + offset] <- FPR[ft]
         // memory[GPR[17] + 0] <- FPR[3]
-        //                       SWC1   base  ft    offset
-        //                              $s1   $f3   0
-        let instruction: u32 = 0b111001_10001_00011_0000000000000000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  SWC1   base  ft    offset
+        //                                         $s1   $f3   0
+        let instructions: Vec<u32> = vec![0b111001_10001_00011_0000000000000000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[17] = 1028; // $s1
         datapath.coprocessor.fpr[3] = f32::to_bits(1.0625f32) as u64;
@@ -1862,23 +1684,21 @@ pub mod coprocessor {
             f32::from_bits(datapath.memory.load_word(1028).unwrap()),
             1.0625f32
         );
+        Ok(())
     }
 
     #[test]
-    pub fn swc1_basic_store_with_offset() {
+    pub fn swc1_basic_store_with_offset() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // swc1 ft, offset(base)
         // swc1 $f5, 32($s0)
         // memory[GPR[base] + offset] <- FPR[ft]
         // memory[GPR[16] + 32] <- FPR[5]
-        //                       SWC1   base  ft    offset
-        //                              $s0   $f5   32
-        let instruction: u32 = 0b111001_10000_00101_0000000000100000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  SWC1   base  ft    offset
+        //                                         $s0   $f5   32
+        let instructions: Vec<u32> = vec![0b111001_10000_00101_0000000000100000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 2000; // $s0
         datapath.coprocessor.fpr[5] = f32::to_bits(3.5f32) as u64;
@@ -1890,10 +1710,11 @@ pub mod coprocessor {
             f32::from_bits(datapath.memory.load_word(2032).unwrap()),
             3.5f32
         );
+        Ok(())
     }
 
     #[test]
-    pub fn swc1_basic_store_64_bit_cutoff() {
+    pub fn swc1_basic_store_64_bit_cutoff() -> Result<(), String> {
         // This test ensures that if there is 64-bit data in a floating-point
         // register, only the bottom 32 bits are stored in memory with this
         // instruction.
@@ -1904,13 +1725,10 @@ pub mod coprocessor {
         // swc1 $f0, 0($s2)
         // memory[GPR[base] + offset] <- FPR[ft]
         // memory[GPR[18] + 0] <- FPR[0]
-        //                       SWC1   base  ft    offset
-        //                              $s2   $f0   0
-        let instruction: u32 = 0b111001_10010_00000_0000000000000000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  SWC1   base  ft    offset
+        //                                         $s2   $f0   0
+        let instructions: Vec<u32> = vec![0b111001_10010_00000_0000000000000000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[18] = 1000; // $s2
         datapath.coprocessor.fpr[0] = f64::to_bits(9853114.625);
@@ -1921,23 +1739,21 @@ pub mod coprocessor {
         // 4162 CB17 5400 0000. When storing the 32-bit word, the bottom 32 bits
         // should be stored, in this case meaning 5400 0000 in hexadecimal.
         assert_eq!(datapath.memory.load_word(1000).unwrap(), 0x5400_0000);
+        Ok(())
     }
 
     #[test]
-    fn lwc1_basic_load_no_offset() {
+    fn lwc1_basic_load_no_offset() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // lwc1 ft, offset(base)
         // lwc1 $f10, 0($t0)
         // FPR[ft] <- memory[GPR[base] + offset]
         // FPR[10] <- memory[GPR[8] + 0]
-        //                       LWC1   base  ft    offset
-        //                              $t0   $f10  0
-        let instruction: u32 = 0b110001_01000_01010_0000000000000000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  LWC1   base  ft    offset
+        //                                         $t0   $f10  0
+        let instructions: Vec<u32> = vec![0b110001_01000_01010_0000000000000000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[8] = 500; // $t0
 
@@ -1954,23 +1770,21 @@ pub mod coprocessor {
             f32::from_bits(datapath.coprocessor.fpr[10] as u32),
             413.125f32
         );
+        Ok(())
     }
 
     #[test]
-    fn lwc1_basic_load_with_offset() {
+    fn lwc1_basic_load_with_offset() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
         // lwc1 ft, offset(base)
         // lwc1 $f11, 200($t1)
         // FPR[ft] <- memory[GPR[base] + offset]
         // FPR[11] <- memory[GPR[9] + 200]
-        //                       LWC1   base  ft    offset
-        //                              $t1   $f11  200
-        let instruction: u32 = 0b110001_01001_01011_0000000011001000;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  LWC1   base  ft    offset
+        //                                         $t1   $f11  200
+        let instructions: Vec<u32> = vec![0b110001_01001_01011_0000000011001000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[9] = 1000; // $t1
 
@@ -1987,6 +1801,7 @@ pub mod coprocessor {
             f32::from_bits(datapath.coprocessor.fpr[11] as u32),
             6.1875f32
         );
+        Ok(())
     }
 
     #[test]
@@ -1997,10 +1812,10 @@ pub mod coprocessor {
         // c.eq.s $f1, $f2
         // CC[0] <- FPR[fs] == FPR[ft]
         // CC[0] <- FPR[1] == FPR[2]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              s     $f2   $f1   0        EQ
-        let instruction: u32 = 0b010001_10000_00010_00001_000_00_110010;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         s     $f2   $f1   0        EQ
+        let instructions: Vec<u32> = vec![0b010001_10000_00010_00001_000_00_110010];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[1] = f32::to_bits(15.5f32) as u64;
         datapath.coprocessor.fpr[2] = f32::to_bits(15.5f32) as u64;
@@ -2020,10 +1835,10 @@ pub mod coprocessor {
         // c.eq.s $f14, $f3
         // CC[0] <- FPR[fs] == FPR[ft]
         // CC[0] <- FPR[14] == FPR[3]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              s     $f3   $f14  0        EQ
-        let instruction: u32 = 0b010001_10000_00011_01110_000_00_110010;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         s     $f3   $f14  0        EQ
+        let instructions: Vec<u32> = vec![0b010001_10000_00011_01110_000_00_110010];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[14] = f32::to_bits(20.125f32) as u64;
         datapath.coprocessor.fpr[3] = f32::to_bits(100f32) as u64;
@@ -2043,10 +1858,10 @@ pub mod coprocessor {
         // c.eq.d $f5, $f9
         // CC[0] <- FPR[fs] == FPR[ft]
         // CC[0] <- FPR[5] == FPR[9]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              d     $f9   $f5   0        EQ
-        let instruction: u32 = 0b010001_10001_01001_00101_000_00_110010;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         d     $f9   $f5   0        EQ
+        let instructions: Vec<u32> = vec![0b010001_10001_01001_00101_000_00_110010];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[5] = f64::to_bits(12951.625);
         datapath.coprocessor.fpr[9] = f64::to_bits(12951.625);
@@ -2066,10 +1881,10 @@ pub mod coprocessor {
         // c.eq.d $f15, $f19
         // CC[0] <- FPR[fs] == FPR[ft]
         // CC[0] <- FPR[15] == FPR[19]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              d     $f19  $f15  0        EQ
-        let instruction: u32 = 0b010001_10001_10011_01111_000_00_110010;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         d     $f19  $f15  0        EQ
+        let instructions: Vec<u32> = vec![0b010001_10001_10011_01111_000_00_110010];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[15] = f64::to_bits(6016.25);
         datapath.coprocessor.fpr[19] = f64::to_bits(820.43);
@@ -2089,10 +1904,10 @@ pub mod coprocessor {
         // c.lt.s $f19, $f0
         // CC[0] <- FPR[fs] < FPR[ft]
         // CC[0] <- FPR[19] < FPR[0]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              s     $f0   $f19  0        LT
-        let instruction: u32 = 0b010001_10000_00000_10011_000_00_111100;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         s     $f0   $f19  0        LT
+        let instructions: Vec<u32> = vec![0b010001_10000_00000_10011_000_00_111100];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[19] = f32::to_bits(2.875f32) as u64;
         datapath.coprocessor.fpr[0] = f32::to_bits(70.6f32) as u64;
@@ -2112,10 +1927,10 @@ pub mod coprocessor {
         // c.lt.s $f30, $f31
         // CC[0] <- FPR[fs] < FPR[ft]
         // CC[0] <- FPR[30] < FPR[31]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              s     $f31  $f30  0        LT
-        let instruction: u32 = 0b010001_10000_11111_11110_000_00_111100;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         s     $f31  $f30  0        LT
+        let instructions: Vec<u32> = vec![0b010001_10000_11111_11110_000_00_111100];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[30] = f32::to_bits(90.7f32) as u64;
         datapath.coprocessor.fpr[31] = f32::to_bits(-87.44f32) as u64;
@@ -2135,10 +1950,10 @@ pub mod coprocessor {
         // c.lt.d $f12, $f29
         // CC[0] <- FPR[fs] < FPR[ft]
         // CC[0] <- FPR[12] < FPR[29]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              d     $f29  $f12  0        LT
-        let instruction: u32 = 0b010001_10001_11101_01100_000_00_111100;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         d     $f29  $f12  0        LT
+        let instructions: Vec<u32> = vec![0b010001_10001_11101_01100_000_00_111100];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[12] = f64::to_bits(4.0);
         datapath.coprocessor.fpr[29] = f64::to_bits(30000.6);
@@ -2158,10 +1973,10 @@ pub mod coprocessor {
         // c.lt.d $f4, $f5
         // CC[0] <- FPR[fs] < FPR[ft]
         // CC[0] <- FPR[4] < FPR[5]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              d     $f5   $f4  0        LT
-        let instruction: u32 = 0b010001_10001_00101_00100_000_00_111100;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         d     $f5   $f4  0        LT
+        let instructions: Vec<u32> = vec![0b010001_10001_00101_00100_000_00_111100];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[4] = f64::to_bits(413.420);
         datapath.coprocessor.fpr[5] = f64::to_bits(-6600.9);
@@ -2181,10 +1996,10 @@ pub mod coprocessor {
         // c.le.s $f0, $f1
         // CC[0] <- FPR[fs] <= FPR[ft]
         // CC[0] <- FPR[0] <= FPR[1]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              s     $f1   $f0   0        LE
-        let instruction: u32 = 0b010001_10000_00001_00000_000_00_111110;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         s     $f1   $f0   0        LE
+        let instructions: Vec<u32> = vec![0b010001_10000_00001_00000_000_00_111110];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[0] = f32::to_bits(171.937f32) as u64;
         datapath.coprocessor.fpr[1] = f32::to_bits(9930.829f32) as u64;
@@ -2204,10 +2019,10 @@ pub mod coprocessor {
         // c.le.s $f2, $f3
         // CC[0] <- FPR[fs] <= FPR[ft]
         // CC[0] <- FPR[2] <= FPR[3]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              s     $f3   $f2   0        LE
-        let instruction: u32 = 0b010001_10000_00011_00010_000_00_111110;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         s     $f3   $f2   0        LE
+        let instructions: Vec<u32> = vec![0b010001_10000_00011_00010_000_00_111110];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[2] = f32::to_bits(6.5f32) as u64;
         datapath.coprocessor.fpr[3] = f32::to_bits(6.5f32) as u64;
@@ -2227,10 +2042,10 @@ pub mod coprocessor {
         // c.le.s $f4, $f5
         // CC[0] <- FPR[fs] <= FPR[ft]
         // CC[0] <- FPR[4] <= FPR[5]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              s     $f5   $f4   0        LE
-        let instruction: u32 = 0b010001_10000_00101_00100_000_00_111110;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         s     $f5   $f4   0        LE
+        let instructions: Vec<u32> = vec![0b010001_10000_00101_00100_000_00_111110];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[4] = f32::to_bits(5742.006f32) as u64;
         datapath.coprocessor.fpr[5] = f32::to_bits(1336.568f32) as u64;
@@ -2250,10 +2065,10 @@ pub mod coprocessor {
         // c.le.d $f6, $f7
         // CC[0] <- FPR[fs] <= FPR[ft]
         // CC[0] <- FPR[6] <= FPR[7]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              d     $f7   $f6   0        LE
-        let instruction: u32 = 0b010001_10001_00111_00110_000_00_111110;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         d     $f7   $f6   0        LE
+        let instructions: Vec<u32> = vec![0b010001_10001_00111_00110_000_00_111110];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[6] = f64::to_bits(3483.70216);
         datapath.coprocessor.fpr[7] = f64::to_bits(7201.56625);
@@ -2273,10 +2088,10 @@ pub mod coprocessor {
         // c.le.d $f8, $f9
         // CC[0] <- FPR[fs] <= FPR[ft]
         // CC[0] <- FPR[8] <= FPR[9]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              d     $f9   $f8   0        LE
-        let instruction: u32 = 0b010001_10001_01001_01000_000_00_111110;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         d     $f9   $f8   0        LE
+        let instructions: Vec<u32> = vec![0b010001_10001_01001_01000_000_00_111110];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[8] = f64::to_bits(77.4009);
         datapath.coprocessor.fpr[9] = f64::to_bits(77.4009);
@@ -2296,10 +2111,10 @@ pub mod coprocessor {
         // c.le.d $f10, $f11
         // CC[0] <- FPR[fs] <= FPR[ft]
         // CC[0] <- FPR[10] <= FPR[11]
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              d     $f11  $f10  0        LE
-        let instruction: u32 = 0b010001_10001_01011_01010_000_00_111110;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         d     $f11  $f10  0        LE
+        let instructions: Vec<u32> = vec![0b010001_10001_01011_01010_000_00_111110];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[10] = f64::to_bits(9190.43309);
         datapath.coprocessor.fpr[11] = f64::to_bits(2869.57622);
@@ -2319,10 +2134,10 @@ pub mod coprocessor {
         // c.ngt.s $f12, $f13
         // CC[0] <- !(FPR[fs] > FPR[ft])
         // CC[0] <- !(FPR[12] > FPR[13])
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              s     $f13  $f12  0        NGT
-        let instruction: u32 = 0b010001_10000_01101_01100_000_00_111111;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         s     $f13  $f12  0        NGT
+        let instructions: Vec<u32> = vec![0b010001_10000_01101_01100_000_00_111111];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[12] = f32::to_bits(2469.465f32) as u64;
         datapath.coprocessor.fpr[13] = f32::to_bits(3505.57f32) as u64;
@@ -2342,10 +2157,10 @@ pub mod coprocessor {
         // c.ngt.s $f14, $f15
         // CC[0] <- !(FPR[fs] > FPR[ft])
         // CC[0] <- !(FPR[14] > FPR[15])
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              s     $f15  $f14  0        NGT
-        let instruction: u32 = 0b010001_10000_01111_01110_000_00_111111;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         s     $f15  $f14  0        NGT
+        let instructions: Vec<u32> = vec![0b010001_10000_01111_01110_000_00_111111];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[14] = f32::to_bits(7099.472f32) as u64;
         datapath.coprocessor.fpr[15] = f32::to_bits(87.198f32) as u64;
@@ -2365,10 +2180,10 @@ pub mod coprocessor {
         // c.ngt.d $f16, $f17
         // CC[0] <- !(FPR[fs] > FPR[ft])
         // CC[0] <- !(FPR[16] > FPR[17])
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              d     $f17  $f16  0        NGT
-        let instruction: u32 = 0b010001_10001_10001_10000_000_00_111111;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         d     $f17  $f16  0        NGT
+        let instructions: Vec<u32> = vec![0b010001_10001_10001_10000_000_00_111111];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[16] = f64::to_bits(7726.4794015);
         datapath.coprocessor.fpr[17] = f64::to_bits(9345.7753943);
@@ -2388,10 +2203,10 @@ pub mod coprocessor {
         // c.ngt.d $f18, $f19
         // CC[0] <- !(FPR[fs] > FPR[ft])
         // CC[0] <- !(FPR[18] > FPR[19])
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              d     $f19  $f18  0        NGT
-        let instruction: u32 = 0b010001_10001_10011_10010_000_00_111111;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         d     $f19  $f18  0        NGT
+        let instructions: Vec<u32> = vec![0b010001_10001_10011_10010_000_00_111111];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[18] = f64::to_bits(4688.2854359);
         datapath.coprocessor.fpr[19] = f64::to_bits(819.7956308);
@@ -2411,10 +2226,10 @@ pub mod coprocessor {
         // c.nge.s $f20, $f21
         // CC[0] <- !(FPR[fs] >= FPR[ft])
         // CC[0] <- !(FPR[20] >= FPR[21])
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              s     $f21  $f20  0        NGE
-        let instruction: u32 = 0b010001_10000_10101_10100_000_00_111101;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         s     $f21  $f20  0        NGE
+        let instructions: Vec<u32> = vec![0b010001_10000_10101_10100_000_00_111101];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[20] = f32::to_bits(3090.244f32) as u64;
         datapath.coprocessor.fpr[21] = f32::to_bits(7396.444f32) as u64;
@@ -2434,10 +2249,10 @@ pub mod coprocessor {
         // c.nge.s $f22, $f23
         // CC[0] <- !(FPR[fs] >= FPR[ft])
         // CC[0] <- !(FPR[22] >= FPR[23])
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              s     $f23  $f22  0        NGE
-        let instruction: u32 = 0b010001_10000_10111_10110_000_00_111101;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         s     $f23  $f22  0        NGE
+        let instructions: Vec<u32> = vec![0b010001_10000_10111_10110_000_00_111101];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[22] = f32::to_bits(6269.823f32) as u64;
         datapath.coprocessor.fpr[23] = f32::to_bits(3089.393f32) as u64;
@@ -2457,10 +2272,10 @@ pub mod coprocessor {
         // c.nge.d $f24, $f25
         // CC[0] <- !(FPR[fs] >= FPR[ft])
         // CC[0] <- !(FPR[24] >= FPR[25])
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              d     $f25  $f24  0        NGE
-        let instruction: u32 = 0b010001_10001_11001_11000_000_00_111101;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         d     $f25  $f24  0        NGE
+        let instructions: Vec<u32> = vec![0b010001_10001_11001_11000_000_00_111101];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[24] = f64::to_bits(819.7956308);
         datapath.coprocessor.fpr[25] = f64::to_bits(4688.2854359);
@@ -2480,10 +2295,10 @@ pub mod coprocessor {
         // c.nge.d $f26, $f27
         // CC[0] <- !(FPR[fs] >= FPR[ft])
         // CC[0] <- !(FPR[26] >= FPR[27])
-        //                       COP1   fmt   ft    fs    cc     __cond
-        //                              d     $f27  $f26  0        NGE
-        let instruction: u32 = 0b010001_10001_11011_11010_000_00_111101;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   fmt   ft    fs    cc     __cond
+        //                                         d     $f27  $f26  0        NGE
+        let instructions: Vec<u32> = vec![0b010001_10001_11011_11010_000_00_111101];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[26] = f64::to_bits(9776.3465875);
         datapath.coprocessor.fpr[27] = f64::to_bits(1549.8268716);
@@ -2503,10 +2318,10 @@ pub mod coprocessor {
         // mtc1 $s0, $f0
         // FPR[fs] <- GPR[rt]
         // FPR[0] <- GPR[16]
-        //                       COP1   sub   rt    fs    0
-        //                              MT    $s0   $f0
-        let instruction: u32 = 0b010001_00100_10000_00000_00000000000;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   sub   rt    fs    0
+        //                                         MT    $s0   $f0
+        let instructions: Vec<u32> = vec![0b010001_00100_10000_00000_00000000000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[16] = 25;
 
@@ -2525,10 +2340,10 @@ pub mod coprocessor {
         // mtc1 $s1, $f1
         // FPR[fs] <- GPR[rt]
         // FPR[1] <- GPR[17]
-        //                       COP1   sub   rt    fs    0
-        //                              MT    $s1   $f1
-        let instruction: u32 = 0b010001_00100_10001_00001_00000000000;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   sub   rt    fs    0
+        //                                         MT    $s1   $f1
+        let instructions: Vec<u32> = vec![0b010001_00100_10001_00001_00000000000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[17] = 0x1234_5678_ABCD_BEEF;
 
@@ -2547,10 +2362,10 @@ pub mod coprocessor {
         // dmtc1 $t0, $f30
         // FPR[fs] <- GPR[rt]
         // FPR[30] <- GPR[8]
-        //                       COP1   sub   rt    fs    0
-        //                              DMT   $t0   $f30
-        let instruction: u32 = 0b010001_00101_01000_11110_00000000000;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   sub   rt    fs    0
+        //                                         DMT   $t0   $f30
+        let instructions: Vec<u32> = vec![0b010001_00101_01000_11110_00000000000];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[8] = 0xDEAD_BEEF_FEED_DEED;
 
@@ -2569,10 +2384,10 @@ pub mod coprocessor {
         // mfc1 $s5, $f18
         // GPR[rt] <- FPR[fs]
         // GPR[21] <- FPR[18]
-        //                       COP1   sub   rt    fs    0
-        //                              MF    $s5   $f18
-        let instruction: u32 = 0b010001_00000_10101_10010_00000000000;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   sub   rt    fs    0
+        //                                         MF    $s5   $f18
+        let instructions: Vec<u32> = vec![0b010001_00000_10101_10010_00000000000];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[18] = 123;
 
@@ -2591,10 +2406,10 @@ pub mod coprocessor {
         // mfc1 $s6, $f19
         // GPR[rt] <- FPR[fs]
         // GPR[22] <- FPR[19]
-        //                       COP1   sub   rt    fs    0
-        //                              MF    $s6   $f19
-        let instruction: u32 = 0b010001_00000_10110_10011_00000000000;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   sub   rt    fs    0
+        //                                         MF    $s6   $f19
+        let instructions: Vec<u32> = vec![0b010001_00000_10110_10011_00000000000];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[19] = 0xABBA_BABB_3ABA_4444;
 
@@ -2613,10 +2428,10 @@ pub mod coprocessor {
         // mfc1 $s7, $f20
         // GPR[rt] <- FPR[fs]
         // GPR[23] <- FPR[20]
-        //                       COP1   sub   rt    fs    0
-        //                              MF    $s7   $f20
-        let instruction: u32 = 0b010001_00000_10111_10100_00000000000;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   sub   rt    fs    0
+        //                                         MF    $s7   $f20
+        let instructions: Vec<u32> = vec![0b010001_00000_10111_10100_00000000000];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[20] = 0xBADA_BEEF_BADA_B00E;
 
@@ -2635,10 +2450,10 @@ pub mod coprocessor {
         // dmfc1 $t8, $f21
         // GPR[rt] <- FPR[fs]
         // GPR[24] <- FPR[21]
-        //                       COP1   sub   rt    fs    0
-        //                              DMF   $t8   $f21
-        let instruction: u32 = 0b010001_00001_11000_10101_00000000000;
-        datapath.memory.store_word(0, instruction)?;
+        //                                  COP1   sub   rt    fs    0
+        //                                         DMF   $t8   $f21
+        let instructions: Vec<u32> = vec![0b010001_00001_11000_10101_00000000000];
+        datapath.initialize(instructions)?;
 
         datapath.coprocessor.fpr[21] = 0xADDA_DADD_1BAA_CAFE;
 
@@ -2653,164 +2468,140 @@ pub mod coprocessor {
 pub mod jump_tests {
     use super::*;
     #[test]
-    fn jump_test_basic() {
+    fn jump_test_basic() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        //                        J
-        let instruction: u32 = 0b000010_00_00000000_00000000_00000010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  J
+        let instructions: Vec<u32> = vec![0b000010_00_00000000_00000000_00000010];
+        datapath.initialize(instructions)?;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.pc, 8);
+        Ok(())
     }
 
     #[test]
-    fn jump_test_mid() {
+    fn jump_test_mid() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        //                        J
-        let instruction: u32 = 0x0800_0fff;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  J
+        let instructions: Vec<u32> = vec![0x0800_0fff];
+        datapath.initialize(instructions)?;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.pc, 0x3ffc);
+        Ok(())
     }
 
     #[test]
-    fn jump_test_hard() {
+    fn jump_test_hard() -> Result<(), String> {
         // Jump to address 0xfff_fffc
         let mut datapath = MipsDatapath::default();
 
-        //                        J             low_26
-        let instruction: u32 = 0x0800_0000 | 0x03ff_ffff;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  J             low_26
+        let instructions: Vec<u32> = vec![0x0800_0000 | 0x03ff_ffff];
+        datapath.initialize(instructions)?;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.pc, 0x0fff_fffc);
+        Ok(())
     }
 }
 
 pub mod jump_and_link_tests {
     use super::*;
     #[test]
-    fn test_basic() {
+    fn test_basic() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
         let old_pc = datapath.registers.pc;
 
-        //                        J
-        let instruction: u32 = 0b000011_00_00000000_00000000_00000010;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  J
+        let instructions: Vec<u32> = vec![0b000011_00_00000000_00000000_00000010];
+        datapath.initialize(instructions)?;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.pc, 8);
         assert_eq!(datapath.registers.gpr[31], old_pc + 4);
+        Ok(())
     }
 
     #[test]
-    fn test_mid() {
+    fn test_mid() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
         let old_pc = datapath.registers.pc;
 
-        //                        J
-        let instruction: u32 = 0x0c00_0fff;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  J
+        let instructions: Vec<u32> = vec![0x0c00_0fff];
+        datapath.initialize(instructions)?;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.pc, 0x3ffc);
         assert_eq!(datapath.registers.gpr[31], old_pc + 4);
+        Ok(())
     }
 
     #[test]
-    fn test_hard() {
+    fn test_hard() -> Result<(), String> {
         // Jump to address 0xfff_fffc
         let mut datapath = MipsDatapath::default();
         let old_pc = datapath.registers.pc;
 
-        //                        J             low_26
-        let instruction: u32 = 0x0c00_0000 | 0x03ff_ffff;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  J             low_26
+        let instructions: Vec<u32> = vec![0x0c00_0000 | 0x03ff_ffff];
+        datapath.initialize(instructions)?;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.pc, 0x0fff_fffc);
         assert_eq!(datapath.registers.gpr[31], old_pc + 4);
+        Ok(())
     }
 }
 
 pub mod beq_tests {
     use super::*;
     #[test]
-    fn beq_test_basic_registers_are_equal() {
+    fn beq_test_basic_registers_are_equal() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        //                        beq
-        let instruction: u32 = 0b000100_01000_10000_0000000000000001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  beq
+        let instructions: Vec<u32> = vec![0b000100_01000_10000_0000000000000001];
+        datapath.initialize(instructions)?;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.pc, 8);
+        Ok(())
     }
 
     #[test]
-    fn beq_test_basic_register_are_not_equal() {
+    fn beq_test_basic_register_are_not_equal() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        //                        beq
-        let instruction: u32 = 0b000100_01000_10000_0000000000000001;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
+        //                                  beq
+        let instructions: Vec<u32> = vec![0b000100_01000_10000_0000000000000001];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[0b01000] = 1234;
         datapath.registers.gpr[0b10000] = 4321;
         datapath.execute_instruction();
 
         assert_eq!(datapath.registers.pc, 4);
+        Ok(())
     }
 
     #[test]
-    fn beq_test_basic_branch_backwards() {
+    fn beq_test_basic_branch_backwards() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
+
+        //                                  beq                +2(branch by +8)
+        let instructions: Vec<u32> = vec![0b000100_01000_10000_0000000000000011];
+        datapath.initialize(instructions)?;
 
         datapath.registers.gpr[0b01000] = 1234;
         datapath.registers.gpr[0b10000] = 1234;
 
-        //                        beq                +2(branch by +8)
-        let instruction: u32 = 0b000100_01000_10000_0000000000000011;
-        datapath
-            .memory
-            .store_word(0, instruction)
-            .expect("Failed to store instruction.");
-        //                        beq               -2 (branch by -8)
-        // let instruction: u32 = 0b000100_01000_10000_1111111111111110;
-
         //                         beq                  (branch by 0)
         let instruction: u32 = 0b000100_01000_10000_0000000000000000;
-        datapath
-            .memory
-            .store_word(16, instruction)
-            .expect("Failed to store instruction.");
+        datapath.memory.store_word(16, instruction)?;
 
         datapath.execute_instruction();
         assert_eq!(datapath.registers.pc, 16);
@@ -2819,6 +2610,7 @@ pub mod beq_tests {
 
         datapath.execute_instruction();
         assert_eq!(datapath.registers.pc, 20);
+        Ok(())
     }
 }
 
@@ -2829,19 +2621,20 @@ pub mod syscall {
     fn halts_on_syscall() -> Result<(), String> {
         let mut datapath = MipsDatapath::default();
 
-        assert!(!datapath.is_halted());
+        assert!(datapath.is_halted());
 
         // This program doubles the value in $t1 and stops.
 
-        // $t1 = $t1 + $t1
-        //                      SPECIAL  t1    t1    t1  (shamt)  ADD
-        let instruction1: u32 = 0b000000_01001_01001_01001_00000_100000;
-        datapath.memory.store_word(0, instruction1)?;
-
-        // syscall
-        //                      SPECIAL       (code)         SYSCALL
-        let instruction2: u32 = 0b000000_00000000000000000000_001100;
-        datapath.memory.store_word(4, instruction2)?;
+        let instructions: Vec<u32> = vec![
+            // $t1 = $t1 + $t1
+            // SPECIAL t1   t1    t1  (shamt)  ADD
+            0b000000_01001_01001_01001_00000_100000,
+            // syscall
+            // SPECIAL     (code)        SYSCALL
+            0b000000_00000000000000000000_001100,
+        ];
+        datapath.initialize(instructions)?;
+        assert!(!datapath.is_halted());
 
         datapath.registers.gpr[9] = 5; // $t1
 

--- a/src/tests/integration/core_parser.rs
+++ b/src/tests/integration/core_parser.rs
@@ -15,7 +15,7 @@ add $s1, $s0, $s0"#,
 
     // Parse instructions and load into emulation core memory.
     let (_, instruction_bits) = parser(instructions);
-    datapath.load_instructions(instruction_bits)?;
+    datapath.initialize(instruction_bits)?;
 
     // Execute 2 instructions.
     for _ in 0..2 {
@@ -54,7 +54,7 @@ dati r1, 43982"#,
 
     // Parse instructions and load into emulation core memory.
     let (_, instruction_bits) = parser(instructions);
-    datapath.load_instructions(instruction_bits)?;
+    datapath.initialize(instruction_bits)?;
 
     // Execute 4 instructions.
     for _ in 0..4 {

--- a/src/ui/console/component.rs
+++ b/src/ui/console/component.rs
@@ -6,7 +6,7 @@ use yew_hooks::prelude::*;
 use crate::emulation_core::mips::datapath::MipsDatapath;
 use crate::ui::visual_datapath::{DatapathSize, VisualDatapath};
 
-#[derive(Properties, PartialEq)]
+#[derive(PartialEq, Properties)]
 pub struct Consoleprops {
     pub datapath: MipsDatapath,
     pub parsermsg: String,

--- a/src/ui/regview/component.rs
+++ b/src/ui/regview/component.rs
@@ -4,13 +4,13 @@ use yew::prelude::*;
 use crate::emulation_core::mips::registers::GpRegisters;
 
 // datapath.coprocessor.fpr
-#[derive(Properties, PartialEq)]
+#[derive(PartialEq, Properties)]
 pub struct Regviewprops {
     pub gp: GpRegisters,
     pub fp: [u64; 32],
 }
 
-#[derive(Properties, PartialEq)]
+#[derive(PartialEq, Properties)]
 pub struct Viewswitch {
     pub switch_view: bool,
 }


### PR DESCRIPTION
Closes #149.

This PR creates a new function in the Datapath API, `is_halted()`, to determine if the datapath is in a stopped state. This can be triggered manually using a `syscall` instruction (as true system calls are not within the scope of the MVP), or triggered by an error. For example, if there is an unsupported instruction.

The exact error message is no longer logged in the browser console, but this is still internally available within the datapath.

In addition:
- All instances of `#derive(...)` have been alphabetized.
- `on_load_clicked` has been renamed to `on_assemble_clicked`, reflecting what the "Assemble" button actually does.
- Registers are no longer printed to the browser console, as they are part of the interface now.
- The execute buttons are disabled if the emulation core is halted.