### PR TITLE
datapath: Revert line state documentation to 77cb156aceefe25e24769700be9ea2459f0ab91d

### DIFF
--- a/src/emulation_core/mips/datapath.rs
+++ b/src/emulation_core/mips/datapath.rs
@@ -80,30 +80,30 @@ pub struct DatapathState {
     /// before the `DataWrite` multiplexer in the main processor.
     pub data_result: u64,
 
-    /// *Jump address line.* The line the will carry the combination of
-    /// the high 32 + 4 bits and pc, and the lower_26_for_jump_line bits shifted
-    /// left by 2.
+    /// *Jump address line.* This line carries the concatenation of
+    /// the high 36 bits of the PC, and `lower_26_shifted_left_by_2`.
     pub jump_address: u64,
 
-    /// *Jump 26 bit line.* The low 26 bits of the instruction reserved
-    /// for possible use by the J instruction
+    /// *Jump 26 bit line.* The lower 26 bits of the instruction reserved
+    /// for the location used by a J-type instruction.
     pub lower_26: u32,
 
-    /// *Lower 26 << 2 line.* This line carries the low 28 bits for the
-    /// jump address
+    /// *Lower 26 << 2 line.* This line carries the lower 28 bits of the
+    /// jump address.
     pub lower_26_shifted_left_by_2: u32,
 
-    /// bla bla bal
+    /// *Data line.* Determines the next value of the PC, given that the
+    /// current instruction is not a jump.
     pub mem_mux1_to_mem_mux2: u64,
 
     /// *Data line.* The data retrieved from memory. Initialized after
     /// the Memory stage.
     pub memory_data: u64,
 
-    /// *New PC line.* In the WB stage this line is written to registers.pc
+    /// *New PC line.* In the WB stage, this line is written to the PC.
     pub new_pc: u64,
 
-    /// *PC + 4 line.* Yeah, just PC + 4
+    /// *Data line.* Contains PC + 4.
     pub pc_plus_4: u64,
 
     /// *Data line.* Data read from the register file based on the `rs`
@@ -120,16 +120,17 @@ pub struct DatapathState {
     /// processor and the main processor register file.
     pub register_write_data: u64,
 
-    /// *Relative PC branch address line
+    /// *Data line.* New PC value used if branching is set for an instruction.
     pub relative_pc_branch: u64,
 
     /// *Data line.* The instruction's immediate value sign-extended to
     /// 64 bits. Initialized after the Instruction Decode stage.
     pub sign_extend: u64,
 
-    /// *Data line.* The sign_extend line but shifted left by two
+    /// *Data line.* The `sign_extend` line, shifted left by two bits.
     pub sign_extend_shift_left_by_2: u64,
 
+    /// *Data line.* The data that will be written to memory.
     pub write_data: u64,
 }
 


### PR DESCRIPTION
Updated documentation was lost in a merge conflict resolution in #132.