### PR TITLE
Parser march 6

### DIFF
--- a/src/parser/parser_structs_and_enums.rs
+++ b/src/parser/parser_structs_and_enums.rs
@@ -1,5 +1,6 @@
 pub mod instruction_tokenization {
     use std::default::Default;
+    use std::fmt;
 
     #[derive(Clone, Debug, Default, Eq, PartialEq)]
     ///Wrapper for all information gathered in the Parser/Assembler about the written program.
@@ -107,6 +108,11 @@ pub mod instruction_tokenization {
         ImproperlyFormattedASCII, //Token recognized as ASCII does not start and or end with "
         ImproperlyFormattedChar, //Token recognized as a char does not end with ' or is larger than a single char
     }
+
+    impl fmt::Display for ErrorType {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "{:?}", self)
+        }}
 
     //this enum is used for the fn read_operands to choose the types of operands expected for an instruction type
     pub enum OperandType {

--- a/src/parser/parser_structs_and_enums.rs
+++ b/src/parser/parser_structs_and_enums.rs
@@ -28,7 +28,7 @@ pub mod instruction_tokenization {
         pub instruction_number: u32,
         pub line_number: u32,
         pub errors: Vec<Error>,
-        pub label: Option<(Token, u32)>,
+        pub label: Option<(Token, u32)>, //label.1 refers to the line number the label is on
     }
 
     ///A collection of all relevant information found about a variable in the Parser/Assembler
@@ -112,7 +112,8 @@ pub mod instruction_tokenization {
     impl fmt::Display for ErrorType {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "{:?}", self)
-        }}
+        }
+    }
 
     //this enum is used for the fn read_operands to choose the types of operands expected for an instruction type
     pub enum OperandType {

--- a/src/parser/parsing.rs
+++ b/src/parser/parsing.rs
@@ -408,7 +408,7 @@ pub fn suggest_error_corrections(
                             }
                         }
 
-                        let mut suggestion = "A valid, similar register is: ".to_string();
+                        let mut suggestion = "GP register is not recognized. A valid, similar register is: ".to_string();
                         suggestion.push_str(&closest.1);
                         suggestion.push_str(".\n");
                         error.message = suggestion;
@@ -431,7 +431,7 @@ pub fn suggest_error_corrections(
                             }
                         }
 
-                        let mut suggestion = "A valid, similar register is: ".to_string();
+                        let mut suggestion = "FP register is not recognized. A valid, similar register is: ".to_string();
                         suggestion.push_str(&closest.1);
                         suggestion.push_str(".\n");
                         error.message = suggestion;
@@ -516,14 +516,6 @@ pub fn suggest_error_corrections(
                         suggestion.push_str(".\n");
                         error.message = suggestion;
                     }
-                    ImproperlyFormattedASCII => {
-                        error.message =
-                            "Token recognized as ASCII does not start and or end with \".\n"
-                                .to_string();
-                    }
-                    ImproperlyFormattedChar => {
-                        error.message = "Token recognized as a char does not end with ' or is larger than a single char.\n".to_string();
-                    }
                     _ => {
                         error.message = "PARSER/ASSEMBLER ERROR. THIS ERROR TYPE SHOULD NOT BE ABLE TO BE ASSOCIATED WITH AN INSTRUCTION.\n".to_string();
                     }
@@ -532,14 +524,16 @@ pub fn suggest_error_corrections(
                     .mouse_hover_string
                     .push_str(&error.message.clone());
 
-                console_out_string.push_str("Error on line ");
+                console_out_string.push_str(&error.error_name.to_string());
+                console_out_string.push_str(" on line ");
                 console_out_string.push_str(&instruction.line_number.to_string());
                 console_out_string.push_str(" with token \"");
                 console_out_string.push_str(&error.token_causing_error);
                 console_out_string.push_str("\"\n");
-                console_out_string.push_str(
-                    &monaco_line_info[instruction.line_number as usize].mouse_hover_string,
-                );
+                console_out_string.push_str(&error.message);
+                console_out_string.push_str("\n");
+
+
             }
         }
     }
@@ -577,6 +571,30 @@ pub fn suggest_error_corrections(
                         "The given label name is already used elsewhere in the project.\n"
                             .to_string();
                 }
+                ImmediateOutOfBounds => {
+                    error.message = "Immediate value given cannot be expressed in the available number of bits.\n".to_string();
+                }
+                ImproperlyFormattedASCII => {
+                    error.message =
+                        "Token recognized as ASCII does not start and or end with double quotes (\").\n"
+                            .to_string();
+                }
+                ImproperlyFormattedChar => {
+                    error.message = "Token recognized as a char does not end with ' or is larger than a single char.\n".to_string();
+                }
+                MissingComma => {
+                    error.message =
+                        "Operand expected to end with a comma but it does not.\n".to_string()
+                }
+                NonIntImmediate => {
+                    error.message =
+                        "The given string cannot be recognized as an integer.\n".to_string();
+                }
+                NonFloatImmediate => {
+                    error.message =
+                        "The given string cannot be recognized as a float.\n".to_string();
+                }
+
                 _ => {
                     error.message = "PARSER/ASSEMBLER ERROR. THIS ERROR TYPE SHOULD NOT BE ABLE TO BE ASSOCIATED WITH DATA.\n".to_string();
                 }
@@ -585,18 +603,21 @@ pub fn suggest_error_corrections(
                 .mouse_hover_string
                 .push_str(&error.message.clone());
 
-            console_out_string.push_str("Error on line ");
+            console_out_string.push_str(&error.error_name.to_string());
+            console_out_string.push_str(" on line ");
             console_out_string.push_str(&datum.line_number.to_string());
             console_out_string.push_str(" with token \"");
             console_out_string.push_str(&error.token_causing_error);
             console_out_string.push_str("\"\n");
             console_out_string
-                .push_str(&monaco_line_info[datum.line_number as usize].mouse_hover_string);
+                .push_str(&error.message.clone());
+            console_out_string.push_str("\n");
+
         }
     }
 
     if console_out_string.is_empty() {
-        console_out_string = "Program assembled successfully!".to_string();
+      return "Program assembled successfully!".to_string();
     }
 
     console_out_string

--- a/src/parser/pseudo_instruction_parsing.rs
+++ b/src/parser/pseudo_instruction_parsing.rs
@@ -109,7 +109,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                     ],
                     binary: 0,
                     instruction_number: instruction.instruction_number + 1,
-                    line_number: 0,
+                    line_number: instruction.instruction_number,
                     errors: vec![],
                     label: None,
                 };
@@ -204,7 +204,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                     ],
                     binary: 0,
                     instruction_number: instruction.instruction_number + 1,
-                    line_number: 0,
+                    line_number: instruction.instruction_number,
                     errors: vec![],
                     label: None,
                 };
@@ -266,7 +266,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                     ],
                     binary: 0,
                     instruction_number: instruction.instruction_number + 1,
-                    line_number: 0,
+                    line_number: instruction.instruction_number,
                     errors: vec![],
                     label: None,
                 };
@@ -373,7 +373,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                     ],
                     binary: 0,
                     instruction_number: instruction.instruction_number + 1,
-                    line_number: 0,
+                    line_number: instruction.instruction_number,
                     errors: vec![],
                     label: None,
                 };
@@ -432,7 +432,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                     ],
                     binary: 0,
                     instruction_number: instruction.instruction_number + 1,
-                    line_number: 0,
+                    line_number: instruction.instruction_number,
                     errors: vec![],
                     label: None,
                 };
@@ -542,7 +542,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                     ],
                     binary: 0,
                     instruction_number: instruction.instruction_number,
-                    line_number: 0,
+                    line_number: instruction.instruction_number,
                     errors: vec![],
                     label: None,
                 };
@@ -594,7 +594,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                     ],
                     binary: 0,
                     instruction_number: instruction.instruction_number,
-                    line_number: 0,
+                    line_number: instruction.instruction_number,
                     errors: vec![],
                     label: None,
                 };
@@ -647,7 +647,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                     ],
                     binary: 0,
                     instruction_number: instruction.instruction_number,
-                    line_number: 0,
+                    line_number: instruction.instruction_number,
                     errors: vec![],
                     label: None,
                 };
@@ -699,7 +699,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                     ],
                     binary: 0,
                     instruction_number: instruction.instruction_number,
-                    line_number: 0,
+                    line_number: instruction.instruction_number,
                     errors: vec![],
                     label: None,
                 };
@@ -752,7 +752,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                     ],
                     binary: 0,
                     instruction_number: instruction.instruction_number,
-                    line_number: 0,
+                    line_number: instruction.instruction_number,
                     errors: vec![],
                     label: None,
                 };
@@ -798,7 +798,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                     ],
                     binary: 0,
                     instruction_number: instruction.instruction_number,
-                    line_number: 0,
+                    line_number: instruction.instruction_number,
                     errors: vec![],
                     label: None,
                 };

--- a/src/parser/pseudo_instruction_parsing.rs
+++ b/src/parser/pseudo_instruction_parsing.rs
@@ -492,7 +492,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                         ],
                         binary: 0,
                         instruction_number: instruction.instruction_number,
-                        line_number: 0,
+                        line_number: instruction.line_number,
                         errors: vec![],
                         label: None,
                     };

--- a/src/tests/parser/parser_assembler_main.rs
+++ b/src/tests/parser/parser_assembler_main.rs
@@ -753,7 +753,7 @@ fn console_output_post_assembly_works_with_errors() {
     .0
     .console_out_post_assembly;
 
-    print!("{}", result);
+    assert_eq!(result, "UnrecognizedGPRegister on line 1 with token \"1235\"\nGP register is not recognized. A valid, similar register is: r23.\n\nUnrecognizedGPRegister on line 5 with token \"t1\"\nGP register is not recognized. A valid, similar register is: $t1.\n\nInvalidMemorySyntax on line 5 with token \"address\"\nThe given string for memory does not match syntax of \"offset(base)\" or \"label\".\n\nImproperlyFormattedASCII on line 3 with token \"100\"\nToken recognized as ASCII does not start and or end with double quotes (\").\n\n")
 }
 
 #[test]

--- a/src/tests/parser/parsing.rs
+++ b/src/tests/parser/parsing.rs
@@ -744,15 +744,15 @@ fn suggest_error_corrections_works_with_various_gp_registers() {
 
     assert_eq!(
         result[0].errors[0].message,
-        "A valid, similar register is: $t3.\n"
+        "GP register is not recognized. A valid, similar register is: $t3.\n"
     );
     assert_eq!(
         result[1].errors[0].message,
-        "A valid, similar register is: $at.\n"
+        "GP register is not recognized. A valid, similar register is: $at.\n"
     );
     assert_eq!(
         result[1].errors[1].message,
-        "A valid, similar register is: r0.\n"
+        "GP register is not recognized. A valid, similar register is: r0.\n"
     );
 }
 
@@ -764,19 +764,19 @@ fn suggest_error_corrections_works_with_various_fp_registers() {
 
     assert_eq!(
         result[0].errors[0].message,
-        "A valid, similar register is: $f3.\n"
+        "FP register is not recognized. A valid, similar register is: $f3.\n"
     );
     assert_eq!(
         result[1].errors[0].message,
-        "A valid, similar register is: $f0.\n"
+        "FP register is not recognized. A valid, similar register is: $f0.\n"
     );
     assert_eq!(
         result[1].errors[1].message,
-        "A valid, similar register is: $f2.\n"
+        "FP register is not recognized. A valid, similar register is: $f2.\n"
     );
     assert_eq!(
         result[1].errors[2].message,
-        "A valid, similar register is: $f0.\n"
+        "FP register is not recognized. A valid, similar register is: $f0.\n"
     );
 }
 

--- a/src/tests/parser/pseudo_instruction_parsing.rs
+++ b/src/tests/parser/pseudo_instruction_parsing.rs
@@ -1,6 +1,8 @@
 use crate::parser::assembling::assemble_data_binary;
 use crate::parser::parser_structs_and_enums::instruction_tokenization::TokenType::Operator;
-use crate::parser::parser_structs_and_enums::instruction_tokenization::{Instruction, print_vec_of_instructions, ProgramInfo, Token};
+use crate::parser::parser_structs_and_enums::instruction_tokenization::{
+    print_vec_of_instructions, Instruction, ProgramInfo, Token,
+};
 use crate::parser::parsing::{create_label_map, separate_data_and_text, tokenize_program};
 use crate::parser::pseudo_instruction_parsing::{
     complete_lw_sw_pseudo_instructions, expand_pseudo_instructions_and_assign_instruction_numbers,
@@ -1383,7 +1385,7 @@ fn expand_pseudo_instructions_and_assign_instruction_numbers_works_sgeu() {
 }
 
 #[test]
-fn complete_lw_sw_pseudo_isntructions_works_multiple_using_same_label(){
+fn complete_lw_sw_pseudo_isntructions_works_multiple_using_same_label() {
     let mut program_info = ProgramInfo::default();
 
     let file_string = ".data\nlabel: .word 100\n.text\nlw $t1, label\nlw $t2, label".to_string();

--- a/src/tests/parser/pseudo_instruction_parsing.rs
+++ b/src/tests/parser/pseudo_instruction_parsing.rs
@@ -1431,7 +1431,7 @@ fn complete_lw_sw_pseudo_instructions_works() {
             ],
             binary: 0,
             instruction_number: 0,
-            line_number: 0,
+            line_number: 3,
             errors: vec![],
             label: None,
         }
@@ -1485,7 +1485,7 @@ fn complete_lw_sw_pseudo_instructions_works() {
             ],
             binary: 0,
             instruction_number: 2,
-            line_number: 0,
+            line_number: 4,
             errors: vec![],
             label: None,
         }

--- a/src/tests/parser/pseudo_instruction_parsing.rs
+++ b/src/tests/parser/pseudo_instruction_parsing.rs
@@ -1,8 +1,6 @@
 use crate::parser::assembling::assemble_data_binary;
 use crate::parser::parser_structs_and_enums::instruction_tokenization::TokenType::Operator;
-use crate::parser::parser_structs_and_enums::instruction_tokenization::{
-    Instruction, ProgramInfo, Token,
-};
+use crate::parser::parser_structs_and_enums::instruction_tokenization::{Instruction, print_vec_of_instructions, ProgramInfo, Token};
 use crate::parser::parsing::{create_label_map, separate_data_and_text, tokenize_program};
 use crate::parser::pseudo_instruction_parsing::{
     complete_lw_sw_pseudo_instructions, expand_pseudo_instructions_and_assign_instruction_numbers,
@@ -1382,6 +1380,34 @@ fn expand_pseudo_instructions_and_assign_instruction_numbers_works_sgeu() {
             label: None,
         }
     );
+}
+
+#[test]
+fn complete_lw_sw_pseudo_isntructions_works_multiple_using_same_label(){
+    let mut program_info = ProgramInfo::default();
+
+    let file_string = ".data\nlabel: .word 100\n.text\nlw $t1, label\nlw $t2, label".to_string();
+
+    let (lines, mut updated_monaco_string, mut monaco_line_info_vec) =
+        tokenize_program(file_string);
+    (program_info.instructions, program_info.data) = separate_data_and_text(lines);
+    expand_pseudo_instructions_and_assign_instruction_numbers(
+        &mut program_info.instructions,
+        &program_info.data,
+        &mut updated_monaco_string,
+        &mut monaco_line_info_vec,
+    );
+    let _vec_of_data = assemble_data_binary(&mut program_info.data);
+    let labels: HashMap<String, u32> =
+        create_label_map(&mut program_info.instructions, &mut program_info.data);
+
+    complete_lw_sw_pseudo_instructions(
+        &mut program_info.instructions,
+        &labels,
+        &mut updated_monaco_string,
+    );
+
+    print_vec_of_instructions(program_info.instructions.clone());
 }
 
 #[test]


### PR DESCRIPTION
Fixed a couple of small things real quick.

Updated the messages for errors. 
On the console error output, the error name is output now, too since there's not the visual indication.
Errors on off-line labels now associate in monaco_line_number with the line with the label instead of the line with the instruction.