### PR TITLE
Double pseudos

### DIFF
--- a/src/parser/parser_assembler_main.rs
+++ b/src/parser/parser_assembler_main.rs
@@ -386,6 +386,62 @@ pub fn read_instructions(instruction_list: &mut [Instruction], labels: &HashMap<
                     None,
                 );
             }
+            "daddu" => {
+                instruction.binary = append_binary(instruction.binary, 0b000000, 6); //special
+
+                read_operands(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![2, 3, 1],
+                    None,
+                );
+
+
+                instruction.binary = append_binary(instruction.binary, 0b00000, 5); //0
+                instruction.binary = append_binary(instruction.binary, 0b101101, 6); //daddu
+            }
+            "dsubu" => {
+                instruction.binary = append_binary(instruction.binary, 0b000000, 6); //special
+
+                read_operands(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![2, 3, 1],
+                    None,
+                );
+
+
+                instruction.binary = append_binary(instruction.binary, 0b00000, 5); //0
+                instruction.binary = append_binary(instruction.binary, 0b101111, 6); //dsubu
+            }
+            "dmulu" => {
+                instruction.binary = append_binary(instruction.binary, 0b000000, 6); //special
+
+                read_operands(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![2, 3, 1],
+                    None,
+                );
+
+
+                instruction.binary = append_binary(instruction.binary, 0b00010, 5); //dmulu
+                instruction.binary = append_binary(instruction.binary, 0b011101, 6); //sop35
+            }
+            "ddivu" => {
+                instruction.binary = append_binary(instruction.binary, 0b000000, 6); //special
+
+                read_operands(
+                    instruction,
+                    vec![RegisterGP, RegisterGP],
+                    vec![1, 2],
+                    None,
+                );
+
+
+                instruction.binary = append_binary(instruction.binary, 0b0000000000, 10); //0
+                instruction.binary = append_binary(instruction.binary, 0b011111, 6); //DDIVU
+            }
             "slt" => {
                 instruction.binary = append_binary(instruction.binary, 0b000000, 6); //special
 
@@ -678,8 +734,7 @@ pub fn read_instructions(instruction_list: &mut [Instruction], labels: &HashMap<
                 //our support for syscall is limited. It is simply there to end emulation
                 instruction.binary = append_binary(instruction.binary, 0b000000, 6); //special
                 instruction.binary = append_binary(instruction.binary, 0b00000000000000000000, 20); //stub of code
-                instruction.binary = append_binary(instruction.binary, 0b001100, 6);
-                //syscall
+                instruction.binary = append_binary(instruction.binary, 0b001100, 6); //syscall
             }
 
             _ => {

--- a/src/parser/parser_assembler_main.rs
+++ b/src/parser/parser_assembler_main.rs
@@ -396,9 +396,9 @@ pub fn read_instructions(instruction_list: &mut [Instruction], labels: &HashMap<
                     None,
                 );
 
-
                 instruction.binary = append_binary(instruction.binary, 0b00000, 5); //0
-                instruction.binary = append_binary(instruction.binary, 0b101101, 6); //daddu
+                instruction.binary = append_binary(instruction.binary, 0b101101, 6);
+                //daddu
             }
             "dsubu" => {
                 instruction.binary = append_binary(instruction.binary, 0b000000, 6); //special
@@ -410,9 +410,9 @@ pub fn read_instructions(instruction_list: &mut [Instruction], labels: &HashMap<
                     None,
                 );
 
-
                 instruction.binary = append_binary(instruction.binary, 0b00000, 5); //0
-                instruction.binary = append_binary(instruction.binary, 0b101111, 6); //dsubu
+                instruction.binary = append_binary(instruction.binary, 0b101111, 6);
+                //dsubu
             }
             "dmulu" => {
                 instruction.binary = append_binary(instruction.binary, 0b000000, 6); //special
@@ -424,23 +424,18 @@ pub fn read_instructions(instruction_list: &mut [Instruction], labels: &HashMap<
                     None,
                 );
 
-
                 instruction.binary = append_binary(instruction.binary, 0b00010, 5); //dmulu
-                instruction.binary = append_binary(instruction.binary, 0b011101, 6); //sop35
+                instruction.binary = append_binary(instruction.binary, 0b011101, 6);
+                //sop35
             }
             "ddivu" => {
                 instruction.binary = append_binary(instruction.binary, 0b000000, 6); //special
 
-                read_operands(
-                    instruction,
-                    vec![RegisterGP, RegisterGP],
-                    vec![1, 2],
-                    None,
-                );
-
+                read_operands(instruction, vec![RegisterGP, RegisterGP], vec![1, 2], None);
 
                 instruction.binary = append_binary(instruction.binary, 0b0000000000, 10); //0
-                instruction.binary = append_binary(instruction.binary, 0b011111, 6); //DDIVU
+                instruction.binary = append_binary(instruction.binary, 0b011111, 6);
+                //DDIVU
             }
             "slt" => {
                 instruction.binary = append_binary(instruction.binary, 0b000000, 6); //special
@@ -734,7 +729,8 @@ pub fn read_instructions(instruction_list: &mut [Instruction], labels: &HashMap<
                 //our support for syscall is limited. It is simply there to end emulation
                 instruction.binary = append_binary(instruction.binary, 0b000000, 6); //special
                 instruction.binary = append_binary(instruction.binary, 0b00000000000000000000, 20); //stub of code
-                instruction.binary = append_binary(instruction.binary, 0b001100, 6); //syscall
+                instruction.binary = append_binary(instruction.binary, 0b001100, 6);
+                //syscall
             }
 
             _ => {

--- a/src/parser/pseudo_instruction_parsing.rs
+++ b/src/parser/pseudo_instruction_parsing.rs
@@ -606,7 +606,58 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                 instruction.operands[2].start_end_columns = (0, 0);
                 instruction.instruction_number += 1;
             }
-            "dsubiu" => {}
+            "dsubiu" => {
+                //dsubiu $regA, $regB, immediate is translated to:
+                //ori $at, $zero, immediate
+                //dsubu $regA, $regB, $at
+
+                monaco_line_info[instruction.line_number as usize].mouse_hover_string =
+                    "dsubiu $regA, $regB, immediate is a pseudo-instruction.\ndsubiu $regA, $regB, immediate =>\n\tori $at, $zero, immediate\n\tdsubu $regA, $regB, $at\n"
+                        .to_string();
+
+                //make sure there are the right number of operands
+                if instruction.operands.len() != 3 {
+                    instruction.errors.push(Error {
+                        error_name: IncorrectNumberOfOperands,
+                        token_causing_error: "".to_string(),
+                        start_end_columns: instruction.operator.start_end_columns,
+                        message: "".to_string(),
+                    });
+                    continue;
+                }
+                let extra_instruction = Instruction {
+                    operator: Token {
+                        token_name: "ori".to_string(),
+                        start_end_columns: (0, 0),
+                        token_type: Operator,
+                    },
+                    operands: vec![
+                        Token {
+                            token_name: "$at".to_string(),
+                            start_end_columns: (0, 0),
+                            token_type: Default::default(),
+                        },
+                        Token {
+                            token_name: "$zero".to_string(),
+                            start_end_columns: (0, 0),
+                            token_type: Default::default(),
+                        },
+                        instruction.operands[2].clone(),
+                    ],
+                    binary: 0,
+                    instruction_number: instruction.instruction_number,
+                    line_number: instruction.instruction_number,
+                    errors: vec![],
+                    label: None,
+                };
+                vec_of_added_instructions.push(extra_instruction);
+                //adjust subi for the added instruction
+                instruction.operator.token_name = "dsubu".to_string();
+                instruction.operator.start_end_columns = (0, 0);
+                instruction.operands[2].token_name = "$at".to_string();
+                instruction.operands[2].start_end_columns = (0, 0);
+                instruction.instruction_number += 1;
+            }
             "muli" => {
                 //muli $regA, $regB, immediate is translated to:
                 //ori $at, $zero, immediate
@@ -711,7 +762,58 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                 instruction.operands[2].start_end_columns = (0, 0);
                 instruction.instruction_number += 1;
             }
-            "dmuliu" => {}
+            "dmuliu" => {
+                //dmuliu $regA, $regB, immediate is translated to:
+                //ori $at, $zero, immediate
+                //dmulu $regA, $regB, $at
+
+                monaco_line_info[instruction.line_number as usize].mouse_hover_string =
+                    "dmuliu $regA, $regB, immediate is a pseudo-instruction.\ndmuliu $regA, $regB, immediate =>\n\tori $at, $zero, immediate\n\tdmulu $regA, $regB, $at\n"
+                        .to_string();
+
+                //make sure the are the right number of operands
+                if instruction.operands.len() != 3 {
+                    instruction.errors.push(Error {
+                        error_name: IncorrectNumberOfOperands,
+                        token_causing_error: "".to_string(),
+                        start_end_columns: instruction.operator.start_end_columns,
+                        message: "".to_string(),
+                    });
+                    continue;
+                }
+                let extra_instruction = Instruction {
+                    operator: Token {
+                        token_name: "ori".to_string(),
+                        start_end_columns: (0, 0),
+                        token_type: Operator,
+                    },
+                    operands: vec![
+                        Token {
+                            token_name: "$at".to_string(),
+                            start_end_columns: (0, 0),
+                            token_type: Default::default(),
+                        },
+                        Token {
+                            token_name: "$zero".to_string(),
+                            start_end_columns: (0, 0),
+                            token_type: Default::default(),
+                        },
+                        instruction.operands[2].clone(),
+                    ],
+                    binary: 0,
+                    instruction_number: instruction.instruction_number,
+                    line_number: instruction.instruction_number,
+                    errors: vec![],
+                    label: None,
+                };
+                vec_of_added_instructions.push(extra_instruction);
+                //adjust subi for the added instruction
+                instruction.operator.token_name = "dmulu".to_string();
+                instruction.operator.start_end_columns = (0, 0);
+                instruction.operands[2].token_name = "$at".to_string();
+                instruction.operands[2].start_end_columns = (0, 0);
+                instruction.instruction_number += 1;
+            }
             "divi" => {
                 //divi $regA, immediate is translated to:
                 //ori $at, $zero, immediate
@@ -810,7 +912,52 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
                 instruction.operands[1].start_end_columns = (0, 0);
                 instruction.instruction_number += 1;
             }
-            "ddiviu" => {}
+            "ddiviu" => {
+                //ddiviu $regA, immediate is translated to:
+                //ori $at, $zero, immediate
+                //ddivu $regA, $at
+
+                monaco_line_info[instruction.line_number as usize].mouse_hover_string =
+                    "ddiviu $regA, immediate is a pseudo-instruction.\nddiviu $regA, immediate =>\n\tori $at, $zero, immediate\n\tddivu $regA, $at\n"
+                        .to_string();
+
+                //make sure the are the right number of operands
+                if instruction.operands.len() != 2 {
+                    continue;
+                }
+                let extra_instruction = Instruction {
+                    operator: Token {
+                        token_name: "ori".to_string(),
+                        start_end_columns: (0, 0),
+                        token_type: Operator,
+                    },
+                    operands: vec![
+                        Token {
+                            token_name: "$at".to_string(),
+                            start_end_columns: (0, 0),
+                            token_type: Default::default(),
+                        },
+                        Token {
+                            token_name: "$zero".to_string(),
+                            start_end_columns: (0, 0),
+                            token_type: Default::default(),
+                        },
+                        instruction.operands[1].clone(),
+                    ],
+                    binary: 0,
+                    instruction_number: instruction.instruction_number,
+                    line_number: instruction.instruction_number,
+                    errors: vec![],
+                    label: None,
+                };
+                vec_of_added_instructions.push(extra_instruction);
+                //adjust subi for the added instruction
+                instruction.operator.token_name = "ddivu".to_string();
+                instruction.operator.start_end_columns = (0, 0);
+                instruction.operands[1].token_name = "$at".to_string();
+                instruction.operands[1].start_end_columns = (0, 0);
+                instruction.instruction_number += 1;
+            }
             _ => {}
         }
     }

--- a/src/tests/parser/parser_assembler_main.rs
+++ b/src/tests/parser/parser_assembler_main.rs
@@ -361,6 +361,54 @@ mod read_instructions_tests {
     }
 
     #[test]
+    fn read_instructions_daddu() {
+        let file_string = "daddu $t1, $t2, $t3".to_string();
+
+        let instruction_list = instruction_parser(file_string);
+
+        assert_eq!(
+            instruction_list[0].binary,
+            0b00000001010010110100100000101101
+        );
+    }
+
+    #[test]
+    fn read_instructions_dsubu() {
+        let file_string = "dsubu $t1, $t2, $t3".to_string();
+
+        let instruction_list = instruction_parser(file_string);
+
+        assert_eq!(
+            instruction_list[0].binary,
+            0b00000001010010110100100000101111
+        );
+    }
+
+    #[test]
+    fn read_instructions_dmulu() {
+        let file_string = "dmulu $t1, $t2, $t3".to_string();
+
+        let instruction_list = instruction_parser(file_string);
+
+        assert_eq!(
+            instruction_list[0].binary,
+            0b00000001010010110100100010011101
+        );
+    }
+
+    #[test]
+    fn read_instructions_ddivu() {
+        let file_string = "ddivu $t1, $t2".to_string();
+
+        let instruction_list = instruction_parser(file_string);
+
+        assert_eq!(
+            instruction_list[0].binary,
+            0b00000001001010100000000000011111
+        );
+    }
+
+    #[test]
     fn read_instructions_slt() {
         let file_string = "slt $t1, $t2, $s6".to_string();
 

--- a/src/tests/parser/pseudo_instruction_parsing.rs
+++ b/src/tests/parser/pseudo_instruction_parsing.rs
@@ -456,6 +456,88 @@ fn expand_pseudo_instructions_and_assign_instruction_numbers_works_dsubi() {
 }
 
 #[test]
+fn expand_pseudo_instructions_and_assign_instruction_numbers_works_dsubiu() {
+    let mut program_info = ProgramInfo::default();
+
+    let file_string = "dsubiu $t1, $t2, 100\nsw $t1, label".to_string();
+
+    let (lines, mut updated_monaco_string, mut monaco_line_info_vec) =
+        tokenize_program(file_string);
+    (program_info.instructions, program_info.data) = separate_data_and_text(lines);
+    expand_pseudo_instructions_and_assign_instruction_numbers(
+        &mut program_info.instructions,
+        &program_info.data,
+        &mut updated_monaco_string,
+        &mut monaco_line_info_vec,
+    );
+
+    assert_eq!(
+        program_info.instructions[0],
+        Instruction {
+            operator: Token {
+                token_name: "ori".to_string(),
+                start_end_columns: (0, 0),
+                token_type: Operator,
+            },
+            operands: vec![
+                Token {
+                    token_name: "$at".to_string(),
+                    start_end_columns: (0, 0),
+                    token_type: Default::default(),
+                },
+                Token {
+                    token_name: "$zero".to_string(),
+                    start_end_columns: (0, 0),
+                    token_type: Default::default(),
+                },
+                Token {
+                    token_name: "100".to_string(),
+                    start_end_columns: (17, 19),
+                    token_type: Default::default(),
+                }
+            ],
+            binary: 0,
+            instruction_number: 0,
+            line_number: 0,
+            errors: vec![],
+            label: None,
+        }
+    );
+    assert_eq!(
+        program_info.instructions[1],
+        Instruction {
+            operator: Token {
+                token_name: "dsubu".to_string(),
+                start_end_columns: (0, 0),
+                token_type: Operator,
+            },
+            operands: vec![
+                Token {
+                    token_name: "$t1".to_string(),
+                    start_end_columns: (7, 10),
+                    token_type: Default::default(),
+                },
+                Token {
+                    token_name: "$t2".to_string(),
+                    start_end_columns: (12, 15),
+                    token_type: Default::default(),
+                },
+                Token {
+                    token_name: "$at".to_string(),
+                    start_end_columns: (0, 0),
+                    token_type: Default::default(),
+                }
+            ],
+            binary: 0,
+            instruction_number: 1,
+            line_number: 0,
+            errors: vec![],
+            label: None,
+        }
+    );
+}
+
+#[test]
 fn expand_pseudo_instructions_and_assign_instruction_numbers_works_dmuli() {
     let mut program_info = ProgramInfo::default();
 
@@ -538,6 +620,88 @@ fn expand_pseudo_instructions_and_assign_instruction_numbers_works_dmuli() {
 }
 
 #[test]
+fn expand_pseudo_instructions_and_assign_instruction_numbers_works_dmuliu() {
+    let mut program_info = ProgramInfo::default();
+
+    let file_string = "dmuliu $t1, $t2, 100\nsw $t1, label".to_string();
+
+    let (lines, mut updated_monaco_string, mut monaco_line_info_vec) =
+        tokenize_program(file_string);
+    (program_info.instructions, program_info.data) = separate_data_and_text(lines);
+    expand_pseudo_instructions_and_assign_instruction_numbers(
+        &mut program_info.instructions,
+        &program_info.data,
+        &mut updated_monaco_string,
+        &mut monaco_line_info_vec,
+    );
+
+    assert_eq!(
+        program_info.instructions[0],
+        Instruction {
+            operator: Token {
+                token_name: "ori".to_string(),
+                start_end_columns: (0, 0),
+                token_type: Operator,
+            },
+            operands: vec![
+                Token {
+                    token_name: "$at".to_string(),
+                    start_end_columns: (0, 0),
+                    token_type: Default::default(),
+                },
+                Token {
+                    token_name: "$zero".to_string(),
+                    start_end_columns: (0, 0),
+                    token_type: Default::default(),
+                },
+                Token {
+                    token_name: "100".to_string(),
+                    start_end_columns: (17, 19),
+                    token_type: Default::default(),
+                }
+            ],
+            binary: 0,
+            instruction_number: 0,
+            line_number: 0,
+            errors: vec![],
+            label: None,
+        }
+    );
+    assert_eq!(
+        program_info.instructions[1],
+        Instruction {
+            operator: Token {
+                token_name: "dmulu".to_string(),
+                start_end_columns: (0, 0),
+                token_type: Operator,
+            },
+            operands: vec![
+                Token {
+                    token_name: "$t1".to_string(),
+                    start_end_columns: (7, 10),
+                    token_type: Default::default(),
+                },
+                Token {
+                    token_name: "$t2".to_string(),
+                    start_end_columns: (12, 15),
+                    token_type: Default::default(),
+                },
+                Token {
+                    token_name: "$at".to_string(),
+                    start_end_columns: (0, 0),
+                    token_type: Default::default(),
+                }
+            ],
+            binary: 0,
+            instruction_number: 1,
+            line_number: 0,
+            errors: vec![],
+            label: None,
+        }
+    );
+}
+
+#[test]
 fn expand_pseudo_instructions_and_assign_instruction_numbers_works_ddivi() {
     let mut program_info = ProgramInfo::default();
 
@@ -597,6 +761,83 @@ fn expand_pseudo_instructions_and_assign_instruction_numbers_works_ddivi() {
                 Token {
                     token_name: "$t1".to_string(),
                     start_end_columns: (6, 9),
+                    token_type: Default::default(),
+                },
+                Token {
+                    token_name: "$at".to_string(),
+                    start_end_columns: (0, 0),
+                    token_type: Default::default(),
+                }
+            ],
+            binary: 0,
+            instruction_number: 1,
+            line_number: 0,
+            errors: vec![],
+            label: None,
+        }
+    );
+}
+
+#[test]
+fn expand_pseudo_instructions_and_assign_instruction_numbers_works_ddiviu() {
+    let mut program_info = ProgramInfo::default();
+
+    let file_string = "ddiviu $t1, 100\nsw $t1, label".to_string();
+
+    let (lines, mut updated_monaco_string, mut monaco_line_info_vec) =
+        tokenize_program(file_string);
+    (program_info.instructions, program_info.data) = separate_data_and_text(lines);
+    expand_pseudo_instructions_and_assign_instruction_numbers(
+        &mut program_info.instructions,
+        &program_info.data,
+        &mut updated_monaco_string,
+        &mut monaco_line_info_vec,
+    );
+
+    assert_eq!(
+        program_info.instructions[0],
+        Instruction {
+            operator: Token {
+                token_name: "ori".to_string(),
+                start_end_columns: (0, 0),
+                token_type: Operator,
+            },
+            operands: vec![
+                Token {
+                    token_name: "$at".to_string(),
+                    start_end_columns: (0, 0),
+                    token_type: Default::default(),
+                },
+                Token {
+                    token_name: "$zero".to_string(),
+                    start_end_columns: (0, 0),
+                    token_type: Default::default(),
+                },
+                Token {
+                    token_name: "100".to_string(),
+                    start_end_columns: (12, 14),
+                    token_type: Default::default(),
+                }
+            ],
+            binary: 0,
+            instruction_number: 0,
+            line_number: 0,
+            errors: vec![],
+            label: None,
+        }
+    );
+    assert_eq!(
+        program_info.instructions[1],
+        Instruction {
+            operator: Token {
+                token_name: "ddivu".to_string(),
+                start_end_columns: (0, 0),
+                token_type: Operator,
+            },
+            operands: vec![
+                Token {
+                    token_name: "$t1".to_string(),
+                    start_end_columns: (7, 10),
                     token_type: Default::default(),
                 },
                 Token {


### PR DESCRIPTION
Added the double unsigned arithmetic instructions recently added to the emulation core to the assembler. 
Added the double unsigned immediate pseudo-instructions dependent on these to the parser.