### PR TITLE
Capitalization is ignored for instructions, directives, and registers

### DIFF
--- a/src/parser/assembling.rs
+++ b/src/parser/assembling.rs
@@ -352,7 +352,7 @@ pub fn read_register(
 ///This function takes a register string as an argument and returns the string of the binary of the matching
 ///general register or none if there is not one that matches.
 pub fn match_gp_register(register: &str) -> Option<u32> {
-    match register {
+    match register.to_lowercase().as_str() {
         "$zero" | "r0" => Some(0b00000), //0
         "$at" | "r1" => Some(0b00001),   //1
 
@@ -399,7 +399,7 @@ pub fn match_gp_register(register: &str) -> Option<u32> {
 ///This function takes a register string as an argument and returns the string of the binary of the matching
 ///floating point register or none if there is not one that matches.
 pub fn match_fp_register(register: &str) -> Option<u32> {
-    match register {
+    match register.to_lowercase().as_str() {
         "$f0" => Some(0b00000),
         "$f1" => Some(0b00001),
         "$f2" => Some(0b00010),
@@ -486,7 +486,7 @@ pub fn assemble_data_binary(data_list: &mut [Data]) -> Vec<u8> {
     let mut vec_of_data: Vec<u8> = Vec::new();
     for datum in data_list.iter_mut() {
         datum.data_number = vec_of_data.len() as u32;
-        match &*datum.data_type.token_name {
+        match &*datum.data_type.token_name.to_lowercase() {
             ".ascii" => {
                 //pushes a string of characters to memory
                 for value in datum.data_entries_and_values.iter_mut() {

--- a/src/parser/parser_assembler_main.rs
+++ b/src/parser/parser_assembler_main.rs
@@ -71,7 +71,7 @@ pub fn read_instructions(
     for mut instruction in &mut instruction_list.iter_mut() {
         //this match case is the heart of the parser and figures out which instruction type it is
         //then it can call the proper functions for that specific instruction
-        match &*instruction.operator.token_name {
+        match &*instruction.operator.token_name.to_lowercase() {
             "add" => {
                 instruction.binary = append_binary(instruction.binary, 0b000000, 6);
 

--- a/src/parser/parsing.rs
+++ b/src/parser/parsing.rs
@@ -126,11 +126,11 @@ pub fn separate_data_and_text(mut lines: Vec<MonacoLineInfo>) -> (Vec<Instructio
     let mut i = 0;
     //goes through each line of the line vector and builds instructions as it goes
     while i < lines.len() {
-        if lines[i].tokens[0].token_name == ".text" {
+        if lines[i].tokens[0].token_name.to_lowercase() == ".text" {
             is_text = true;
             i += 1;
             continue;
-        } else if lines[i].tokens[0].token_name == ".data" {
+        } else if lines[i].tokens[0].token_name.to_lowercase() == ".data" {
             is_text = false;
             i += 1;
             continue;

--- a/src/parser/pseudo_instruction_parsing.rs
+++ b/src/parser/pseudo_instruction_parsing.rs
@@ -33,7 +33,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers(
     //iterate through every instruction and check if the operator is a pseudo-instruction
     for (i, mut instruction) in &mut instructions.iter_mut().enumerate() {
         instruction.instruction_number = (i + vec_of_added_instructions.len()) as u32;
-        match &*instruction.operator.token_name {
+        match &*instruction.operator.token_name.to_lowercase() {
             "li" => {
                 monaco_line_info[instruction.line_number as usize].mouse_hover_string =
                     "li is a pseudo-instruction.\nli regA, immediate =>\n\tori $regA, $zero, immediate\n"

--- a/src/tests/parser/parser_assembler_main.rs
+++ b/src/tests/parser/parser_assembler_main.rs
@@ -855,3 +855,27 @@ fn mouse_hover_holds_information_info_for_various_instruction_types() {
     assert_eq!(program_info.monaco_line_info[3].mouse_hover_string, "add rd, rs, rt\nAdds the 32-bit values in rs and rt, and places the result in rd.\nIn hardware implementations, the result is not placed in rd if adding rs and rt causes a 32-bit overflow. However, SWIM places the result in rd, regardless.\n\nBinary: 00000001010010110100100000100000");
     assert_eq!(program_info.monaco_line_info[4].mouse_hover_string, "syscall\nThis function is currently stubbed in SWIM. Normally, it reverts control back to the OS. SWIM uses it to effectively end the program.\n\nBinary: 00000000000000000000000000001100");
 }
+
+#[test]
+fn instructions_directives_and_registers_work_regardless_of_capitalization() {
+    let result =
+        parser(".TexT\nOR $t1, $T2, $t3\nor $t1, $t2, $t3\n.DATA\nabel: .WOrD 100".to_string());
+
+    let correct =
+        parser(".TexT\nOR $t1, $T2, $t3\nor $t1, $t2, $t3\n.DATA\nabel: .WOrD 100".to_lowercase());
+    assert_eq!(result.1, correct.1);
+    assert_eq!(
+        result.0.console_out_post_assembly,
+        correct.0.console_out_post_assembly
+    );
+    assert_eq!(
+        result.0.address_to_line_number,
+        correct.0.address_to_line_number
+    );
+    for i in 0..result.0.monaco_line_info.len() {
+        assert_eq!(
+            result.0.monaco_line_info[i].mouse_hover_string,
+            correct.0.monaco_line_info[i].mouse_hover_string
+        );
+    }
+}


### PR DESCRIPTION
Parser / Assembler is now capitalization agnostic on instructions, directives, and registers