### PR TITLE
RISC-V parser with support for all targeted extensions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,10 +31,13 @@ use yew::prelude::*;
 use yew::{html, Html, Properties};
 use yew_hooks::prelude::*;
 
+//use gloo_console::log;
+
 // To load in the Fibonacci example, uncomment the CONTENT and fib_model lines
 // and comment the code, language, and text_model lines. IMPORTANT:
 // rename fib_model to text_model to have it work.
-const CONTENT: &str = include_str!("../static/assembly_examples/fibonacci.asm");
+// const CONTENT: &str = include_str!("../static/assembly_examples/fibonacci.asm");
+const CONTENT: &str = include_str!("../static/assembly_examples/riscv_test.asm");
 
 #[function_component(App)]
 fn app() -> Html {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,8 @@ use yew_hooks::prelude::*;
 // To load in the Fibonacci example, uncomment the CONTENT and fib_model lines
 // and comment the code, language, and text_model lines. IMPORTANT:
 // rename fib_model to text_model to have it work.
-// const CONTENT: &str = include_str!("../static/assembly_examples/fibonacci.asm");
-const CONTENT: &str = include_str!("../static/assembly_examples/riscv_test.asm");
+const CONTENT: &str = include_str!("../static/assembly_examples/fibonacci.asm");
+// const CONTENT: &str = include_str!("../static/assembly_examples/riscv_test.asm");
 
 #[function_component(App)]
 fn app() -> Html {

--- a/src/parser/assembling.rs
+++ b/src/parser/assembling.rs
@@ -194,7 +194,8 @@ pub fn read_operands_riscv(
     expected_operands: Vec<OperandType>,
     concat_order: Vec<usize>,
     labels_option: Option<HashMap<String, usize>>,
-    funct3: Option<u32>
+    funct3: Option<u32>,
+    fmt: Option<u32>
 ) -> &mut Instruction {
     //if the number of operands in the instruction does not match the expected number, there is an error
     if instruction.operands.len() != expected_operands.len() {
@@ -302,7 +303,7 @@ pub fn read_operands_riscv(
                 instruction.operands[i].token_type = TokenType::RegisterFP;
 
                 bit_lengths.push(5);
-                let register_results = read_register(
+                let register_results = read_register_riscv(
                     &instruction.operands[i].token_name,
                     instruction.operands[i].start_end_columns,
                     FloatingPoint,
@@ -367,9 +368,13 @@ pub fn read_operands_riscv(
             binary_representation[element - 1],
             bit_lengths[element - 1],
         );
-        if index == 1 && funct3.is_some() // Set funct3 value before the final argument
+        if index == concat_order.len() - 2 && funct3.is_some() // Set funct3 value before the final argument
         {
-            instruction.binary = append_binary(instruction.binary, funct3.unwrap_or(0), 3) // Shift amount may need to be adjusted using function argument
+            instruction.binary = append_binary(instruction.binary, funct3.unwrap_or(0), 3)
+        }
+        else if index == 0 && fmt.is_some()
+        {
+            instruction.binary = append_binary(instruction.binary, fmt.unwrap_or(0), 2)
         }
     }
 

--- a/src/parser/assembling.rs
+++ b/src/parser/assembling.rs
@@ -6,7 +6,7 @@ use crate::parser::parser_structs_and_enums::ErrorType::{
     NonIntImmediate, UnrecognizedDataType, UnrecognizedFPRegister, UnrecognizedGPRegister,
 };
 use crate::parser::parser_structs_and_enums::OperandType::{
-    Immediate, LabelAbsolute, LabelRelative, MemoryAddress, RegisterFP, RegisterGP,
+    Immediate, UpperImmediate, LabelAbsolute, LabelRelative, MemoryAddress, RegisterFP, RegisterGP, ShiftAmount
 };
 use crate::parser::parser_structs_and_enums::RegisterType::{FloatingPoint, GeneralPurpose};
 use crate::parser::parser_structs_and_enums::TokenType::{
@@ -16,6 +16,10 @@ use crate::parser::parser_structs_and_enums::{
     Data, Error, Instruction, OperandType, RegisterType, TokenType, FP_REGISTERS, GP_REGISTERS,
 };
 use std::collections::HashMap;
+
+use super::parser_structs_and_enums::{RISCV_GP_REGISTERS, RISCV_FP_REGISTERS};
+
+use gloo_console::log;
 
 ///This function takes an instruction whose operands it is supposed to read, the order of expected operand types and then
 ///the order these operands should be concatenated onto the binary representation of the string
@@ -87,6 +91,10 @@ pub fn read_operands(
                     instruction.errors.push(immediate_results.1.unwrap());
                 }
             }
+            UpperImmediate =>
+            {
+                // Don't need to handle for MIPS
+            }
             MemoryAddress => {
                 instruction.operands[i].token_type = TokenType::MemoryAddress;
 
@@ -152,7 +160,7 @@ pub fn read_operands(
                     instruction.errors.push(label_relative_results.1.unwrap());
                 }
             }
-            OperandType::ShiftAmount => {
+            ShiftAmount => {
                 instruction.operands[i].token_type = TokenType::Immediate;
                 bit_lengths.push(5);
 
@@ -176,6 +184,193 @@ pub fn read_operands(
             binary_representation[element - 1],
             bit_lengths[element - 1],
         );
+    }
+
+    instruction
+}
+
+pub fn read_operands_riscv(
+    instruction: &mut Instruction,
+    expected_operands: Vec<OperandType>,
+    concat_order: Vec<usize>,
+    labels_option: Option<HashMap<String, usize>>,
+    funct3: Option<u32>
+) -> &mut Instruction {
+    //if the number of operands in the instruction does not match the expected number, there is an error
+    if instruction.operands.len() != expected_operands.len() {
+        instruction.errors.push(Error {
+            error_name: IncorrectNumberOfOperands,
+            token_causing_error: instruction.operator.token_name.clone(),
+            start_end_columns: instruction.operator.start_end_columns,
+            message: "".to_string(),
+        });
+        return instruction;
+    }
+
+    let labels = if let Some(..) = labels_option {
+        labels_option.unwrap()
+    } else {
+        HashMap::new()
+    };
+
+    //operands aren't represented in the binary in the order they're read so the vec<u32> allows us to concatenate them in the proper order after they're all read.
+    let mut binary_representation: Vec<u32> = Vec::new();
+    let mut bit_lengths: Vec<u8> = Vec::new();
+    //goes through once for each expected operand
+    for (i, operand_type) in expected_operands.iter().enumerate() {
+        //break if there are no more operands to read. Should only occur if IncorrectNumberOfOperands occurs above
+        if i >= instruction.operands.len() {
+            break;
+        };
+
+        //match case calls the proper functions based on the expected operand type. The data returned from these functions is always
+        //the binary of the read operand and the option for any errors encountered while reading the operand. If there were no errors,
+        //the binary is pushed to the string representations vec. Otherwise, the errors are pushed to the instruction.errors vec.
+        match operand_type {
+            RegisterGP => {
+                log!("RegisterGP");
+                instruction.operands[i].token_type = TokenType::RegisterGP;
+                bit_lengths.push(5);
+
+                let register_results = read_register_riscv(
+                    &instruction.operands[i].token_name,
+                    instruction.operands[i].start_end_columns,
+                    GeneralPurpose,
+                );
+                
+                log!("Register Results:  ", format!("{:?}", register_results));
+
+                // Vector holding all register arguments
+                binary_representation.push(register_results.0 as u32);
+                if register_results.1.is_some() {
+                    instruction.errors.push(register_results.1.unwrap());
+                }
+            }
+            Immediate => {
+                instruction.operands[i].token_type = TokenType::Immediate;
+                bit_lengths.push(12); // 12 bits to represent immediates
+
+                let immediate_results = read_immediate(
+                    &instruction.operands[i].token_name,
+                    instruction.operands[i].start_end_columns,
+                    12,
+                );
+
+                binary_representation.push(immediate_results.0);
+                if immediate_results.1.is_some() {
+                    instruction.errors.push(immediate_results.1.unwrap());
+                }
+            }
+            UpperImmediate => // Can be used to represent offsets for J-type instructions
+            {
+                log!("Upper Immediate");
+                instruction.operands[i].token_type = TokenType::Immediate;
+                bit_lengths.push(20); // 20 bits to represent upper immediates
+
+                let immediate_results = read_immediate(
+                    &instruction.operands[i].token_name,
+                    instruction.operands[i].start_end_columns,
+                    20,
+                );
+
+                binary_representation.push(immediate_results.0);
+                if immediate_results.1.is_some() {
+                    instruction.errors.push(immediate_results.1.unwrap());
+                }
+            }
+            MemoryAddress => {
+                instruction.operands[i].token_type = TokenType::MemoryAddress;
+
+                bit_lengths.push(12);
+                bit_lengths.push(5);
+                //memory address works a bit differently because it really amounts to two operands: the offset and base
+                //meaning there are two values to push and the possibility of errors on both operands
+                let memory_results = read_memory_address_riscv(
+                    &instruction.operands[i].token_name,
+                    instruction.operands[i].start_end_columns,
+                );
+
+                binary_representation.push(memory_results.0);
+                binary_representation.push(memory_results.1);
+                if memory_results.2.is_some() {
+                    for error in memory_results.2.unwrap() {
+                        instruction.errors.push(error);
+                    }
+                }
+            }
+            RegisterFP => {
+                instruction.operands[i].token_type = TokenType::RegisterFP;
+
+                bit_lengths.push(5);
+                let register_results = read_register(
+                    &instruction.operands[i].token_name,
+                    instruction.operands[i].start_end_columns,
+                    FloatingPoint,
+                );
+
+                binary_representation.push(register_results.0 as u32);
+                if register_results.1.is_some() {
+                    instruction.errors.push(register_results.1.unwrap());
+                }
+            }
+            LabelAbsolute => {
+                instruction.operands[i].token_type = TokenType::LabelOperand;
+
+                bit_lengths.push(26);
+                let label_absolute_results = read_label_absolute(
+                    &instruction.operands[i].token_name,
+                    instruction.operands[i].start_end_columns,
+                    labels.clone(),
+                );
+
+                binary_representation.push(label_absolute_results.0);
+                if label_absolute_results.1.is_some() {
+                    instruction.errors.push(label_absolute_results.1.unwrap());
+                }
+            }
+            LabelRelative => {
+                instruction.operands[i].token_type = TokenType::LabelOperand;
+
+                bit_lengths.push(16);
+                let label_relative_results = read_label_relative(
+                    &instruction.operands[i].token_name,
+                    instruction.operands[i].start_end_columns,
+                    instruction.instruction_number,
+                    labels.clone(),
+                );
+                binary_representation.push(label_relative_results.0);
+                if label_relative_results.1.is_some() {
+                    instruction.errors.push(label_relative_results.1.unwrap());
+                }
+            }
+            ShiftAmount => {
+                instruction.operands[i].token_type = TokenType::Immediate;
+                bit_lengths.push(7);
+
+                let immediate_results = read_immediate(
+                    &instruction.operands[i].token_name,
+                    instruction.operands[i].start_end_columns,
+                    7,
+                );
+
+                binary_representation.push(immediate_results.0);
+                if immediate_results.1.is_some() {
+                    instruction.errors.push(immediate_results.1.unwrap());
+                }
+            }
+        }
+    }
+    //once all operands are read, we can append them onto the instruction
+    for (index, element) in concat_order.iter().rev().enumerate() {
+        instruction.binary = append_binary(
+            instruction.binary,
+            binary_representation[element - 1],
+            bit_lengths[element - 1],
+        );
+        if index == 1 && funct3.is_some() // Set funct3 value before the final argument
+        {
+            instruction.binary = append_binary(instruction.binary, funct3.unwrap_or(0), 3) // Shift amount may need to be adjusted using function argument
+        }
     }
 
     instruction
@@ -300,6 +495,78 @@ pub fn read_memory_address(
     (immediate_results.0, register_results.0 as u32, None)
 }
 
+///Takes in a memory address and token number and returns the binary for the offset value, base register value, and any errors.
+/// If the string given matches a label, that address is returned instead
+pub fn read_memory_address_riscv(
+    orig_string: &str,
+    start_end_columns: (usize, usize),
+) -> (u32, u32, Option<Vec<Error>>) {
+    //the indices of the open and close parentheses are checked.
+    //If either are missing or they are in the wrong order, an error is returned
+    let open_index = orig_string.find('(');
+    let close_index = orig_string.find(')');
+    if close_index.is_none() || open_index.is_none() || close_index < open_index {
+        return (
+            0,
+            0,
+            Some(vec![Error {
+                error_name: InvalidMemorySyntax,
+                token_causing_error: orig_string.to_string(),
+                start_end_columns,
+                message: "".to_string(),
+            }]),
+        );
+    }
+
+    //splits the string at the index of the open parenthesis to isolate the base and offset
+    let (offset_str, base_str) = orig_string.split_at(open_index.unwrap());
+
+    let mut base: Vec<char> = base_str.chars().collect();
+
+    //returns an error if there are any characters after the close parenthesis
+    if base[base.len() - 1] != ')' {
+        return (
+            0,
+            0,
+            Some(vec![Error {
+                error_name: InvalidMemorySyntax,
+                token_causing_error: orig_string.to_string(),
+                start_end_columns,
+                message: "".to_string(),
+            }]),
+        );
+    }
+
+    //removes the open and close parentheses characters and then turns it into a string
+    base = base[1..base.len() - 1].to_owned();
+    let mut cleaned_base: String = base.into_iter().collect();
+    cleaned_base = cleaned_base.to_string();
+
+    //offset is an immediate while base is a register so the read functions for those operands
+    //will confirm they are properly formatted
+    let immediate_results = read_immediate(offset_str, start_end_columns, 16);
+    let register_results = read_register_riscv(&cleaned_base, start_end_columns, GeneralPurpose);
+
+    log!("Immediate: ", format!("{:?}", immediate_results));
+    log!("Register: ", format!("{:?}", register_results));
+
+    //any errors found in the read_immediate or read_register functions are collected into a vec
+    //if there were any errors, those are returned
+    let mut return_errors: Vec<Error> = Vec::new();
+    if immediate_results.1.is_some() {
+        return_errors.push(immediate_results.1.unwrap())
+    }
+    if register_results.1.is_some() {
+        return_errors.push(register_results.1.unwrap());
+    }
+    if !return_errors.is_empty() {
+        return (0, 0, Some(return_errors));
+    }
+
+    //if the function reaches here and hasn't already returned, there aren't any errors
+    (immediate_results.0, register_results.0 as u32, None)
+}
+
 ///read_register takes the string of the register name, the token number the register is from the corresponding instruction
 ///and the expected register type. It calls the corresponding functions holding the match cases for the different register types.
 pub fn read_register(
@@ -312,7 +579,7 @@ pub fn read_register(
         let general_result = match_gp_register(register);
         if let Some(..) = general_result {
             (general_result.unwrap(), None)
-        } else if match_fp_register(register).is_some() {
+        } else if match_fp_register(register).is_some() { // Creates Error if supplied a fp register for gp
             (
                 0,
                 Some(Error {
@@ -362,10 +629,85 @@ pub fn read_register(
     }
 }
 
+///read_register takes the string of the register name, the token number the register is from the corresponding instruction
+///and the expected register type. It calls the corresponding functions holding the match cases for the different register types.
+pub fn read_register_riscv(
+    register: &str,
+    start_end_columns: (usize, usize),
+    register_type: RegisterType,
+) -> (u8, Option<Error>) {
+    if register_type == GeneralPurpose {
+        //this section is for matching general purpose registers
+        let general_result = match_gp_register_riscv(register);
+        if let Some(..) = general_result {
+            (general_result.unwrap(), None)
+        } else if match_fp_register_riscv(register).is_some() { // Creates Error if supplied a fp register for gp
+            (
+                0,
+                Some(Error {
+                    error_name: IncorrectRegisterTypeFP,
+                    token_causing_error: register.to_string(),
+                    start_end_columns,
+                    message: "".to_string(),
+                }),
+            )
+        } else {
+            (
+                0,
+                Some(Error {
+                    error_name: UnrecognizedGPRegister,
+                    token_causing_error: register.to_string(),
+                    start_end_columns,
+                    message: "".to_string(),
+                }),
+            )
+        }
+    } else {
+        //this section is for matching floating point registers
+        let floating_result = match_fp_register_riscv(register);
+        if let Some(..) = floating_result {
+            (floating_result.unwrap(), None)
+        } else if match_gp_register(register).is_some() {
+            (
+                0,
+                Some(Error {
+                    error_name: IncorrectRegisterTypeGP,
+                    token_causing_error: register.to_string(),
+                    start_end_columns,
+                    message: "".to_string(),
+                }),
+            )
+        } else {
+            (
+                0,
+                Some(Error {
+                    error_name: UnrecognizedFPRegister,
+                    token_causing_error: register.to_string(),
+                    start_end_columns,
+                    message: "".to_string(),
+                }),
+            )
+        }
+    }
+}
+
 ///This function takes a register string as an argument and returns the string of the binary of the matching
 ///general register or none if there is not one that matches.
 pub fn match_gp_register(given_string: &str) -> Option<u8> {
     for register in GP_REGISTERS {
+        for name in register.names {
+            if &given_string.to_lowercase().as_str() == name {
+                return Some(register.binary);
+            }
+        }
+    }
+    None
+}
+
+///This function takes a register string as an argument and returns the string of the binary of the matching
+///general register or none if there is not one that matches.
+pub fn match_gp_register_riscv(given_string: &str) -> Option<u8> {
+    for register in RISCV_GP_REGISTERS {
         for name in register.names {
             if &given_string.to_lowercase().as_str() == name {
                 return Some(register.binary);
@@ -381,6 +723,19 @@ pub fn match_fp_register(given_string: &str) -> Option<u8> {
     for register in FP_REGISTERS {
         if given_string.to_lowercase() == register.name {
             return Some(register.binary);
+        }
+    }
+    None
+}
+
+///This function takes a register string as an argument and returns the string of the binary of the matching
+///floating point register or none if there is not one that matches.
+pub fn match_fp_register_riscv(given_string: &str) -> Option<u8> {
+    for register in RISCV_FP_REGISTERS {
+        for name in register.names {
+            if &given_string.to_lowercase().as_str() == name {
+                return Some(register.binary);
+            }
         }
     }
     None

--- a/src/parser/assembling.rs
+++ b/src/parser/assembling.rs
@@ -6,7 +6,8 @@ use crate::parser::parser_structs_and_enums::ErrorType::{
     NonIntImmediate, UnrecognizedDataType, UnrecognizedFPRegister, UnrecognizedGPRegister,
 };
 use crate::parser::parser_structs_and_enums::OperandType::{
-    Immediate, UpperImmediate, LabelAbsolute, LabelRelative, MemoryAddress, RegisterFP, RegisterGP, ShiftAmount
+    Immediate, LabelAbsolute, LabelRelative, MemoryAddress, RegisterFP, RegisterGP, ShiftAmount,
+    UpperImmediate,
 };
 use crate::parser::parser_structs_and_enums::RegisterType::{FloatingPoint, GeneralPurpose};
 use crate::parser::parser_structs_and_enums::TokenType::{
@@ -17,7 +18,7 @@ use crate::parser::parser_structs_and_enums::{
 };
 use std::collections::HashMap;
 
-use super::parser_structs_and_enums::{RISCV_GP_REGISTERS, RISCV_FP_REGISTERS};
+use super::parser_structs_and_enums::{RISCV_FP_REGISTERS, RISCV_GP_REGISTERS};
 
 use gloo_console::log;
 
@@ -91,8 +92,7 @@ pub fn read_operands(
                     instruction.errors.push(immediate_results.1.unwrap());
                 }
             }
-            UpperImmediate =>
-            {
+            UpperImmediate => {
                 // Don't need to handle for MIPS
             }
             MemoryAddress => {
@@ -195,7 +195,7 @@ pub fn read_operands_riscv(
     concat_order: Vec<usize>,
     labels_option: Option<HashMap<String, usize>>,
     funct3: Option<u32>,
-    fmt: Option<u32>
+    fmt: Option<u32>,
 ) -> &mut Instruction {
     //if the number of operands in the instruction does not match the expected number, there is an error
     if instruction.operands.len() != expected_operands.len() {
@@ -238,7 +238,7 @@ pub fn read_operands_riscv(
                     instruction.operands[i].start_end_columns,
                     GeneralPurpose,
                 );
-                
+
                 log!("Register Results:  ", format!("{:?}", register_results));
 
                 // Vector holding all register arguments
@@ -262,7 +262,8 @@ pub fn read_operands_riscv(
                     instruction.errors.push(immediate_results.1.unwrap());
                 }
             }
-            UpperImmediate => // Can be used to represent offsets for J-type instructions
+            UpperImmediate =>
+            // Can be used to represent offsets for J-type instructions
             {
                 log!("Upper Immediate");
                 instruction.operands[i].token_type = TokenType::Immediate;
@@ -368,12 +369,11 @@ pub fn read_operands_riscv(
             binary_representation[element - 1],
             bit_lengths[element - 1],
         );
-        if index == concat_order.len() - 2 && funct3.is_some() // Set funct3 value before the final argument
+        if index == concat_order.len() - 2 && funct3.is_some()
+        // Set funct3 value before the final argument
         {
             instruction.binary = append_binary(instruction.binary, funct3.unwrap_or(0), 3)
-        }
-        else if index == 0 && fmt.is_some()
-        {
+        } else if index == 0 && fmt.is_some() {
             instruction.binary = append_binary(instruction.binary, fmt.unwrap_or(0), 2)
         }
     }
@@ -584,7 +584,8 @@ pub fn read_register(
         let general_result = match_gp_register(register);
         if let Some(..) = general_result {
             (general_result.unwrap(), None)
-        } else if match_fp_register(register).is_some() { // Creates Error if supplied a fp register for gp
+        } else if match_fp_register(register).is_some() {
+            // Creates Error if supplied a fp register for gp
             (
                 0,
                 Some(Error {
@@ -646,7 +647,8 @@ pub fn read_register_riscv(
         let general_result = match_gp_register_riscv(register);
         if let Some(..) = general_result {
             (general_result.unwrap(), None)
-        } else if match_fp_register_riscv(register).is_some() { // Creates Error if supplied a fp register for gp
+        } else if match_fp_register_riscv(register).is_some() {
+            // Creates Error if supplied a fp register for gp
             (
                 0,
                 Some(Error {

--- a/src/parser/parser_assembler_main.rs
+++ b/src/parser/parser_assembler_main.rs
@@ -1572,7 +1572,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, RegisterGP],
                     vec![1, 2, 3],
                     None,
-                    Some(0b000)
+                    Some(0b000),
+                    None
                 );
 
                 // Opcode
@@ -1604,7 +1605,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, RegisterGP],
                     vec![1, 2, 3],
                     None,
-                    Some(0b000)
+                    Some(0b000),
+                    None
                 );
 
                 // Opcode
@@ -1636,7 +1638,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, RegisterGP],
                     vec![1, 2, 3],
                     None,
-                    Some(0b001)
+                    Some(0b001),
+                    None
                 );
 
                 // Opcode
@@ -1668,7 +1671,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, RegisterGP],
                     vec![1, 2, 3],
                     None,
-                    Some(0b010)
+                    Some(0b010),
+                    None
                 );
 
                 // Opcode
@@ -1700,7 +1704,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, RegisterGP],
                     vec![1, 2, 3],
                     None,
-                    Some(0b011)
+                    Some(0b011),
+                    None
                 );
 
                 // Opcode
@@ -1732,7 +1737,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, RegisterGP],
                     vec![1, 2, 3],
                     None,
-                    Some(0b100)
+                    Some(0b100),
+                    None
                 );
 
                 // Opcode
@@ -1764,7 +1770,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, RegisterGP],
                     vec![1, 2, 3],
                     None,
-                    Some(0b101)
+                    Some(0b101),
+                    None
                 );
 
                 // Opcode
@@ -1796,7 +1803,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, RegisterGP],
                     vec![1, 2, 3],
                     None,
-                    Some(0b101)
+                    Some(0b101),
+                    None
                 );
 
                 // Opcode
@@ -1828,7 +1836,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, RegisterGP],
                     vec![1, 2, 3],
                     None,
-                    Some(0b110)
+                    Some(0b110),
+                    None
                 );
 
                 // Opcode
@@ -1860,7 +1869,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, RegisterGP],
                     vec![1, 2, 3],
                     None,
-                    Some(0b111)
+                    Some(0b111),
+                    None
                 );
 
                 // Opcode
@@ -1888,7 +1898,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, Immediate],
                     vec![1, 2, 3],
                     None,
-                    Some(0)
+                    Some(0),
+                    None
                 );
 
                 // Opcode
@@ -1916,7 +1927,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, Immediate],
                     vec![1, 2, 3],
                     None,
-                    Some(0b010)
+                    Some(0b010),
+                    None
                 );
 
                 // Opcode
@@ -1944,7 +1956,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, Immediate],
                     vec![1, 2, 3],
                     None,
-                    Some(0b011)
+                    Some(0b011),
+                    None
                 );
 
                 // Opcode
@@ -1972,7 +1985,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, Immediate],
                     vec![1, 2, 3],
                     None,
-                    Some(0b100)
+                    Some(0b100),
+                    None
                 );
 
                 // Opcode
@@ -2000,7 +2014,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, Immediate],
                     vec![1, 2, 3],
                     None,
-                    Some(0b110)
+                    Some(0b110),
+                    None
                 );
 
                 // Opcode
@@ -2028,7 +2043,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, Immediate],
                     vec![1, 2, 3],
                     None,
-                    Some(0b111)
+                    Some(0b111),
+                    None
                 );
 
                 // Opcode
@@ -2059,7 +2075,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, ShiftAmount],
                     vec![1, 2, 3],
                     None,
-                    Some(0b001)
+                    Some(0b001),
+                    None
                 );
 
                 // Opcode
@@ -2090,7 +2107,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, ShiftAmount],
                     vec![1, 2, 3],
                     None,
-                    Some(0b101)
+                    Some(0b101),
+                    None
                 );
 
                 // Opcode
@@ -2121,7 +2139,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, RegisterGP, ShiftAmount],
                     vec![1, 2, 3],
                     None,
-                    Some(0b101)
+                    Some(0b101),
+                    None
                 );
 
                 // Opcode
@@ -2149,7 +2168,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, MemoryAddress],
                     vec![1, 3, 2],
                     None,
-                    Some(0b000)
+                    Some(0b000),
+                    None
                 );
 
                 // Opcode
@@ -2177,7 +2197,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, MemoryAddress],
                     vec![1, 3, 2],
                     None,
-                    Some(0b001)
+                    Some(0b001),
+                    None
                 );
 
                 // Opcode
@@ -2205,7 +2226,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, MemoryAddress],
                     vec![1, 3, 2],
                     None,
-                    Some(0b010)
+                    Some(0b010),
+                    None
                 );
 
                 // Opcode
@@ -2233,7 +2255,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, MemoryAddress],
                     vec![1, 3, 2],
                     None,
-                    Some(0b100)
+                    Some(0b100),
+                    None
                 );
 
                 // Opcode
@@ -2261,7 +2284,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, MemoryAddress],
                     vec![1, 3, 2],
                     None,
-                    Some(0b101)
+                    Some(0b101),
+                    None
                 );
 
                 // Opcode
@@ -2289,7 +2313,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, MemoryAddress],
                     vec![1, 3, 2],
                     None,
-                    Some(0b000)
+                    Some(0b000),
+                    None
                 );
 
                 // Opcode
@@ -2321,7 +2346,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, MemoryAddress],
                     vec![1, 3, 2],
                     None,
-                    Some(0b001)
+                    Some(0b001),
+                    None
                 );
 
                 // Opcode
@@ -2353,7 +2379,8 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, MemoryAddress],
                     vec![1, 3, 2],
                     None,
-                    Some(0b010)
+                    Some(0b010),
+                    None
                 );
 
                 // Opcode
@@ -2376,15 +2403,17 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "jal" =>
+            "jal" => // Finish J instructions
             {
                 log!("jal instruction");
                 log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
 
+                // Read as U-type instruction and reorder immediate value after
                 read_operands_riscv(
                     instruction,
                     vec![RegisterGP, UpperImmediate],
                     vec![1, 2],
+                    None,
                     None,
                     None
                 );
@@ -2394,6 +2423,8 @@ pub fn read_instructions_riscv(
                 log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
 
                 // Reorder immediate
+                instruction.binary = upper_to_jump(instruction.binary);
+                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2407,6 +2438,367 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
+            "jalr" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, MemoryAddress],
+                    vec![1, 3, 2],
+                    None,
+                    Some(0b000),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1100111, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "jalr rd, rs1, offset".to_string(),
+                        description: "Jump to address and place return address in rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "beq" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, Immediate],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                instruction.binary = immediate_to_branch(instruction.binary);
+                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "beq rs1, rs2, offset".to_string(),
+                        description: "Take the branch if registers rs1 and rs2 are equal.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "bne" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, Immediate],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b001),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                instruction.binary = immediate_to_branch(instruction.binary);
+                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "bne rs1, rs2, offset".to_string(),
+                        description: "Take the branch if registers rs1 and rs2 are not equal.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "blt" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, Immediate],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b100),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                instruction.binary = immediate_to_branch(instruction.binary);
+                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "blt rs1, rs2, offset".to_string(),
+                        description: "Take the branch if registers rs1 is less than rs2, using signed comparison.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "bge" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, Immediate],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b101),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                instruction.binary = immediate_to_branch(instruction.binary);
+                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "bge rs1, rs2, offset".to_string(),
+                        description: "Take the branch if registers rs1 is greater than or equal to rs2, using signed comparison.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "bltu" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, Immediate],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b110),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                instruction.binary = immediate_to_branch(instruction.binary);
+                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "bltu rs1, rs2, offset".to_string(),
+                        description: "Take the branch if registers rs1 is less than rs2, using unsigned comparison.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "bgeu" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, Immediate],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b111),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                instruction.binary = immediate_to_branch(instruction.binary);
+                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "bgeu rs1, rs2, offset".to_string(),
+                        description: "Take the branch if registers rs1 is greater than or equal to rs2, using unsigned comparison.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "ecall" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // ecall instruction encoding does not change
+                instruction.binary = 0b00000000000000000000000001110011;
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "ecall".to_string(),
+                        description: "Make a request to the supporting execution environment.\n\nWhen executed in U-mode, S-mode, or M-mode, it generates an environment-call-from-U-mode exception, environment-call-from-S-mode exception, or environment-call-from-M-mode exception, respectively, and performs no other operation.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "ebreak" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // ebreak instruction encoding does not change
+                instruction.binary = 0b00000000000100000000000001110011;
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "ebreak".to_string(),
+                        description: "Used by debuggers to cause control to be transferred back to a debugging environment.\n\nIt generates a breakpoint exception and performs no other operation.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "uret" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // uret instruction encoding does not change
+                instruction.binary = 0b00000000001000000000000001110011;
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "uret".to_string(),
+                        description: "Return from traps in U-mode, and URET copies UPIE into UIE, then sets UPIE.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "sret" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // uret instruction encoding does not change
+                instruction.binary = 0b00010000001000000000000001110011;
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "uret".to_string(),
+                        description: "Return from traps in U-mode, and URET copies UPIE into UIE, then sets UPIE.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "mret" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // uret instruction encoding does not change
+                instruction.binary = 0b00110000001000000000000001110011;
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "mret".to_string(),
+                        description: "Return from traps in M-mode, and MRET copies MPIE into MIE, then sets MPIE.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "wfi" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // uret instruction encoding does not change
+                instruction.binary = 0b00010000010100000000000001110011;
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "wfi".to_string(),
+                        description: "Provides a hint to the implementation that the current hart can be stalled until an interrupt might need servicing.\n\nExecution of the WFI instruction can also be used to inform the hardware platform that suitable interrupts should preferentially be routed to this hart.\n\nWFI is available in all privileged modes, and optionally available to U-mode.\n\nThis instruction may raise an illegal instruction exception when TW=1 in mstatus.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fence.i" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // fence.i instruction encoding does not change
+                instruction.binary = 0b00000000000000000001000000001111;
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fence.i".to_string(),
+                        description: "Provides explicit synchronization between writes to instruction memory and instruction fetches on the same hart.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
             "lui" =>
             {
                 log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
@@ -2415,6 +2807,7 @@ pub fn read_instructions_riscv(
                     instruction,
                     vec![RegisterGP, UpperImmediate],
                     vec![1, 2],
+                    None,
                     None,
                     None
                 );
@@ -2445,6 +2838,7 @@ pub fn read_instructions_riscv(
                     vec![RegisterGP, UpperImmediate],
                     vec![1, 2],
                     None,
+                    None,
                     None
                 );
 
@@ -2460,6 +2854,2625 @@ pub fn read_instructions_riscv(
                     let info = InstructionDescription{
                         syntax: "auipc rd, imm".to_string(),
                         description: "Build pc-relative addresses and uses the U-type format.\n\nAUIPC forms a 32-bit offset from the 20-bit U-immediate, filling in the lowest 12 bits with zeros, adds this offset to the pc, then places the result in register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "addiw" => // Start of RV64I Instructions
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, Immediate],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0011011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "addiw rd, rs1, imm".to_string(),
+                        description: "Adds the sign-extended 12-bit immediate to register rs1 and produces the proper sign-extension of a 32-bit result in rd.\n\nOverflows are ignored and the result is the low 32 bits of the result sign-extended to 64 bits.\n\nNote, ADDIW rd, rs1, 0 writes the sign-extension of the lower 32 bits of register rs1 into register rd (assembler pseudoinstruction SEXT.W).".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "slliw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, ShiftAmount],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b001),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0011011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "slliw rd, rs1, shamt".to_string(),
+                        description: "Performs logical left shift on the 32-bit of value in register rs1 by the shift amount held in the lower 5 bits of the immediate.\n\nEncodings with $imm[5] neq 0$ are reserved.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "srliw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, ShiftAmount],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b101),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0011011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "srliw rd, rs1, shamt".to_string(),
+                        description: "Performs logical right shift on the 32-bit of value in register rs1 by the shift amount held in the lower 5 bits of the immediate.\n\nEncodings with $imm[5] neq 0$ are reserved.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "sraiw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b01000, 7);
+                
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, ShiftAmount],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b101),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0011011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "sraiw rd, rs1, shamt".to_string(),
+                        description: "Performs arithmetic right shift on the 32-bit of value in register rs1 by the shift amount held in the lower 5 bits of the immediate.\n\nEncodings with $imm[5] neq 0$ are reserved.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "addw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "addw rd, rs1, rs2".to_string(),
+                        description: "Adds the 32-bit of registers rs1 and 32-bit of register rs2 and stores the result in rd.\n\nArithmetic overflow is ignored and the low 32-bits of the result is sign-extended to 64-bits and written to the destination register.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "subw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0100000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "subw rd, rs1, rs2".to_string(),
+                        description: "Subtract the 32-bit of registers rs1 and 32-bit of register rs2 and stores the result in rd.\n\nArithmetic overflow is ignored and the low 32-bits of the result is sign-extended to 64-bits and written to the destination register.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "sllw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b001),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "sllw rd, rs1, rs2".to_string(),
+                        description: "Performs logical left shift on the low 32-bits value in register rs1 by the shift amount held in the lower 5 bits of register rs2 and produce 32-bit results and written to the destination register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "srlw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b101),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "srlw rd, rs1, rs2".to_string(),
+                        description: "Performs logical right shift on the low 32-bits value in register rs1 by the shift amount held in the lower 5 bits of register rs2 and produce 32-bit results and written to the destination register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "sraw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0100000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b101),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "sraw rd, rs1, rs2".to_string(),
+                        description: "Performs arithmetic right shift on the low 32-bits value in register rs1 by the shift amount held in the lower 5 bits of register rs2 and produce 32-bit results and written to the destination register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "lwu" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, MemoryAddress],
+                    vec![1, 3, 2],
+                    None,
+                    Some(0b110),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0000011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "lwu rd, offset(rs1)".to_string(),
+                        description: "Loads a 32-bit value from memory and zero-extends this to 64 bits before storing it in register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "ld" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, MemoryAddress],
+                    vec![1, 3, 2],
+                    None,
+                    Some(0b011),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0000011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "ld rd, offset(rs1)".to_string(),
+                        description: "Loads a 64-bit value from memory into register rd for RV64I.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "sd" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, MemoryAddress],
+                    vec![1, 3, 2],
+                    None,
+                    Some(0b011),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0100011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Encoded as I-type, but needs reordering for S-type
+                instruction.binary = immediate_to_stored(instruction.binary);
+                log!("3. Reordered: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "sd rs2, offset(rs1)".to_string(),
+                        description: "Store 64-bit, values from register rs2 to memory.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "mul" => // Start of RV32M
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "mul rd, rs1, rs2".to_string(),
+                        description: "Performs an XLEN-bit * XLEN-bit multiplication of signed rs1 by signed rs2 and places the lower XLEN bits in the destination register.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "mulh" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b001),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "mulh rd, rs1, rs2".to_string(),
+                        description: "Performs an XLEN-bit * XLEN-bit multiplication of signed rs1 by signed rs2 and places the upper XLEN bits in the destination register.
+                       ".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "mulhsu" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b010),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "mulhsu rd, rs1, rs2".to_string(),
+                        description: "Performs an XLEN-bit * XLEN-bit multiplication of signed rs1 by unsigned rs2 and places the upper XLEN bits in the destination register.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "mulhu" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b011),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "mulhu rd, rs1, rs2".to_string(),
+                        description: "Performs an XLEN-bit * XLEN-bit multiplication of unsigned rs1 by unsigned rs2 and places the upper XLEN bits in the destination register.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "div" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b100),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "div rd, rs1, rs2".to_string(),
+                        description: "Perform an XLEN bits by XLEN bits signed integer division of rs1 by rs2, rounding towards zero.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "divu" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b101),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "divu rd, rs1, rs2".to_string(),
+                        description: "Perform an XLEN bits by XLEN bits unsigned integer division of rs1 by rs2, rounding towards zero.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "rem" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b110),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "rem rd, rs1, rs2".to_string(),
+                        description: "Perform an XLEN bits by XLEN bits signed integer remainder of rs1 by rs2.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "remu" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b111),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "remu rd, rs1, rs2".to_string(),
+                        description: "Perform an XLEN bits by XLEN bits unsigned integer remainder of rs1 by rs2.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "mulw" => // Start of RV64M
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "mulw rd, rs1, rs2".to_string(),
+                        description: "Multiplies the lower 32 bits of the source registers, placing the sign-extension of the lower 32 bits of the result into the destination register.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "divw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b100),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "divw rd, rs1, rs2".to_string(),
+                        description: "Perform an XLEN bits by XLEN bits signed integer division of rs1 by rs2.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "divuw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b101),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "divuw rd, rs1, rs2".to_string(),
+                        description: "Perform an XLEN bits by XLEN bits unsigned integer division of rs1 by rs2.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "remw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b110),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "remw rd, rs1, rs2".to_string(),
+                        description: "Perform an XLEN bits by XLEN bits signed integer remainder of rs1 by rs2.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "remuw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct7
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterGP, RegisterGP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b111),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "remuw rd, rs1, rs2".to_string(),
+                        description: "Perform an XLEN bits by XLEN bits unsigned integer reminder of rs1 by rs2.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmadd.s" => // Start of RV32F
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3, 4],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    Some(0b00)
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1000011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmadd.s rd, rs1, rs2, rs3".to_string(),
+                        description: "Multiplies the values in rs1 and rs2, adds the value in rs3, and writes the final result to rd.\n\nFMADD.S computes (rs1 * rs2) + rs3".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmsub.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3, 4],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    Some(0b00)
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1000111, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmsub.s rd, rs1, rs2, rs3".to_string(),
+                        description: "Multiplies the values in rs1 and rs2, subtracts the value in rs3, and writes the final result to rd.\n\nFMSUB.S computes (rs1×rs2) - rs3.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fnmsub.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3, 4],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    Some(0b00)
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1001011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fnmsub.s rd, rs1, rs2, rs3".to_string(),
+                        description: "Multiplies the values in rs1 and rs2, negates the product, adds the value in rs3, and writes the final result to rd.\n\nFNMSUB.S computes -(rs1 * rs2) + rs3.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fnmadd.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3, 4],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    Some(0b00)
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1001111, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fnmadd.s rd, rs1, rs2, rs3".to_string(),
+                        description: "multiplies the values in rs1 and rs2, negates the product, subtracts the value in rs3, and writes the final result to rd.\n\nFNMADD.S computes -(rs1 * rs2) - rs3.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fadd.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fadd.s rd, rs1, rs2".to_string(),
+                        description: "Perform single-precision floating-point addition.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsub.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0000100, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsub.s rd, rs1, rs2".to_string(),
+                        description: "Perform single-precision floating-point substraction.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmul.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0001000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmul.s rd, rs1, rs2".to_string(),
+                        description: "Perform single-precision floating-point multiplication.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fdiv.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0001100, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fdiv.s rd, rs1, rs2".to_string(),
+                        description: "Perform single-precision floating-point division.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsqrt.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + padding for absent register
+                instruction.binary = append_binary(instruction.binary, 0b010110000000, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsqrt.s rd, rs1".to_string(),
+                        description: "Perform single-precision square root.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsgnj.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0010000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsgnj.s rd, rs1, rs2".to_string(),
+                        description: "Produce a result that takes all bits except the sign bit from rs1.\n\nThe result's sign bit is rs2's sign bit.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsgnjn.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0010000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b001), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsgnjn.s rd, rs1, rs2".to_string(),
+                        description: "Produce a result that takes all bits except the sign bit from rs1.\n\nThe result's sign bit is opposite of rs2's sign bit.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsgnjx.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0010000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b010), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsgnjx.s rd, rs1, rs2".to_string(),
+                        description: "Produce a result that takes all bits except the sign bit from rs1.\n\nThe result's sign bit is XOR of sign bit of rs1 and rs2.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmin.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0010100, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmin.s rd, rs1, rs2".to_string(),
+                        description: "Write the smaller of single precision data in rs1 and rs2 to rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmax.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0010100, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b001), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmax.s rd, rs1, rs2".to_string(),
+                        description: "Write the larger of single precision data in rs1 and rs2 to rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.w.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + padding for absent register
+                instruction.binary = append_binary(instruction.binary, 0b110000000000, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.w.s rd, rs1".to_string(),
+                        description: "Convert a floating-point number in floating-point register rs1 to a signed 32-bit in integer register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.wu.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b110000000001, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.wu.s rd, rs1".to_string(),
+                        description: "Convert a floating-point number in floating-point register rs1 to a signed 32-bit in unsigned integer register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmv.x.w" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b111000000000, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b000), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmv.x.w rd, rs1".to_string(),
+                        description: "Move the single-precision value in floating-point register rs1 represented in IEEE 754-2008 encoding to the lower 32 bits of integer register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "feq.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b1010000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b010), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "feq.s rd, rs1, rs2".to_string(),
+                        description: "Performs a quiet equal comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.\n\nOnly signaling NaN inputs cause an Invalid Operation exception.\n\nThe result is 0 if either operand is NaN.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "flt.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b1010000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b001), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "flt.s rd, rs1, rs2".to_string(),
+                        description: "Performs a quiet less comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.\n\nOnly signaling NaN inputs cause an Invalid Operation exception.\n\nThe result is 0 if either operand is NaN.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fle.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b1010000, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fle.s rd, rs1, rs2".to_string(),
+                        description: "Performs a quiet less or equal comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.\n\nOnly signaling NaN inputs cause an Invalid Operation exception.\n\nThe result is 0 if either operand is NaN.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fclass.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b111000000000, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b001), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fclass.s rd, rs1".to_string(),
+                        description: "Examines the value in floating-point register rs1 and writes to integer register rd a 10-bit mask that indicates the class of the floating-point number.\n\nThe corresponding bit in rd will be set if the property is true and clear otherwise. All other bits in rd are cleared.\n\nNote that exactly one bit in rd will be set.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.s.w" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b110100000000, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterGP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.s.w rd, rs1".to_string(),
+                        description: "Converts a 32-bit signed integer, in integer register rs1 into a floating-point number in floating-point register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.s.wu" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b110100000001, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterGP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.s.wu rd, rs1".to_string(),
+                        description: "Converts a 32-bit unsigned integer, in integer register rs1 into a floating-point number in floating-point register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmv.w.x" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b111100000000, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterGP],
+                    vec![1, 2],
+                    None,
+                    Some(0b000), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmv.w.x rd, rs1".to_string(),
+                        description: "Move the single-precision value encoded in IEEE 754-2008 standard encoding from the lower 32 bits of integer register rs1 to the floating-point register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmadd.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3, 4],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    Some(0b01)
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1000011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmadd.d rd, rs1, rs2, rs3".to_string(),
+                        description: "Multiplies the values in rs1 and rs2, adds the value in rs3, and writes the final result tord.\n\nFMADD.D computes (rs1 * rs2) + rs3.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmsub.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3, 4],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    Some(0b01)
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1000111, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmsub.d rd, rs1, rs2, rs3".to_string(),
+                        description: "Multiplies the values in rs1 and rs2, subtracts the value in rs3, and writes the final result to rd. FMSUB.D computes (rs1 * rs2) - rs3".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fnmsub.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3, 4],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    Some(0b01)
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1001011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fnmsub.d rd, rs1, rs2, rs3".to_string(),
+                        description: "Multiplies the values in rs1 and rs2, negates the product, adds the value in rs3, and writes the final result to rd.\n\nFNMSUB.D computes -(rs1 * rs2) + rs3.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fnmadd.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3, 4],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    Some(0b01)
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1001111, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fnmadd.d rd, rs1, rs2, rs3".to_string(),
+                        description: "Multiplies the values in rs1 and rs2, negates the product, subtracts the value in rs3, and writes the final result to rd.\n\nFNMADD.D computes -(rs1 * rs2) - rs3".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fadd.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fadd.d rd, rs1, rs2".to_string(),
+                        description: "Perform single-precision floating-point addition.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsub.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0000101, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsub.d rd, rs1, rs2".to_string(),
+                        description: "Perform single-precision floating-point subtraction.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmul.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0001001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmul.d rd, rs1, rs2".to_string(),
+                        description: "Perform single-precision floating-point multiplication.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fdiv.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0001101, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fdiv.d rd, rs1, rs2".to_string(),
+                        description: "Perform single-precision floating-point division.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsqrt.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b010110100000, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsqrt.d rd, rs1".to_string(),
+                        description: "Perform single-precision square root.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsgnj.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0010001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsgnj.d rd, rs1, rs2".to_string(),
+                        description: "Produce a result that takes all bits except the sign bit from rs1.\n\nThe result's sign bit is rs2's sign bit.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsgnjn.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0010001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b001), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsgnjn.d rd, rs1, rs2".to_string(),
+                        description: "Produce a result that takes all bits except the sign bit from rs1.\n\nThe result's sign bit is opposite of rs2's sign bit.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsgnjx.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0010001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b010), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsgnjx.d rd, rs1, rs2".to_string(),
+                        description: "Produce a result that takes all bits except the sign bit from rs1.\n\nThe result's sign bit is XOR of sign bit of rs1 and rs2.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmin.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0010101, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmin.d rd, rs1, rs2".to_string(),
+                        description: "Write the smaller of single precision data in rs1 and rs2 to rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fmax.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b0010101, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b001), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fmax.d rd, rs1, rs2".to_string(),
+                        description: "Write the larger of single precision data in rs1 and rs2 to rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.s.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b010000000001, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.s.d rd, rs1".to_string(),
+                        description: "Converts double floating-point register in rs1 into a floating-point number in floating-point register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.d.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b010000100000, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.d.s rd, rs1".to_string(),
+                        description: "Converts single floating-point register in rs1 into a double floating-point number in floating-point register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "feq.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b1010001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b010), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "feq.d rd, rs1, rs2".to_string(),
+                        description: "Performs a quiet equal comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.\n\nOnly signaling NaN inputs cause an Invalid Operation exception.\n\nThe result is 0 if either operand is NaN.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "flt.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b1010001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b001), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "flt.d rd, rs1, rs2".to_string(),
+                        description: "Performs a quiet less comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.\n\nOnly signaling NaN inputs cause an Invalid Operation exception.\n\nThe result is 0 if either operand is NaN.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fle.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt
+                instruction.binary = append_binary(instruction.binary, 0b1010001, 7);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP, RegisterFP],
+                    vec![1, 2, 3],
+                    None,
+                    Some(0b000), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fle.d rd, rs1, rs2".to_string(),
+                        description: "Performs a quiet less or equal comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.\n\nOnly signaling NaN inputs cause an Invalid Operation exception.\n\nThe result is 0 if either operand is NaN.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fclass.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b111000100000, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b001), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fclass.d rd, rs1".to_string(),
+                        description: "Examines the value in floating-point register rs1 and writes to integer register rd a 10-bit mask that indicates the class of the floating-point number.\n\nThe corresponding bit in rd will be set if the property is true and clear otherwise.\nAll other bits in rd are cleared.\n\nNote that exactly one bit in rd will be set.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.w.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b110000100000, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.w.d rd, rs1".to_string(),
+                        description: "Converts a double-precision floating-point number in floating-point register rs1 to a signed 32-bit integer, in integer register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.wu.d" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b110000100001, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.wu.d rd, rs1".to_string(),
+                        description: "Converts a double-precision floating-point number in floating-point register rs1 to a unsigned 32-bit integer, in integer register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.d.w" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b110100100000, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterGP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.d.w rd, rs1".to_string(),
+                        description: "Converts a 32-bit signed integer, in integer register rs1 into a double-precision floating-point number in floating-point register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.d.wu" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b110100100001, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterGP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.d.wu rd, rs1".to_string(),
+                        description: "Converts a 32-bit unsigned integer, in integer register rs1 into a double-precision floating-point number in floating-point register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "flw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, MemoryAddress],
+                    vec![1, 3, 2],
+                    None,
+                    Some(0b010),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0000111, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "flw rd, offset(rs1)".to_string(),
+                        description: "Load a single-precision floating-point value from memory into floating-point register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsw" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, MemoryAddress],
+                    vec![1, 3, 2],
+                    None,
+                    Some(0b010),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0100111, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Encoded as I-type, but needs reordering for S-type
+                instruction.binary = immediate_to_stored(instruction.binary);
+                log!("3. Reordered: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsw rs2, offset(rs1)".to_string(),
+                        description: "Store a single-precision value from floating-point register rs2 to memory.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fld" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, MemoryAddress],
+                    vec![1, 3, 2],
+                    None,
+                    Some(0b011),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0000111, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fld rd, rs1, offset".to_string(),
+                        description: "Load a double-precision floating-point value from memory into floating-point register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fsd" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, MemoryAddress],
+                    vec![1, 3, 2],
+                    None,
+                    Some(0b011),
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b0100111, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Encoded as I-type, but needs reordering for S-type
+                instruction.binary = immediate_to_stored(instruction.binary);
+                log!("3. Reordered: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fsd rs2, offset(rs1)".to_string(),
+                        description: "Store a double-precision value from the floating-point registers to memory.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.l.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b110000000010, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.l.s rd, rs1".to_string(),
+                        description: "Converts the floating-point value in register rs1 (interpreted as a single-precision floating-point number) to a signed 32-bit integer.\n\nThe result is then stored in integer register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.lu.s" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b110000000011, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterGP, RegisterFP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.lu.s rd, rs1".to_string(),
+                        description: "This instruction converts the floating-point value in register rs1 (interpreted as a single-precision floating-point number) to an unsigned 32-bit integer.\n\nThe result is then stored in integer register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.s.l" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b110100000010, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterGP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.s.l rd, rs1".to_string(),
+                        description: "Converts the signed 32-bit integer value in register rs1 to a single-precision floating-point number.\n\nThe result is then stored in floating-point register rd.".to_string(),
+                    };
+                    monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+                }
+            }
+            "fcvt.s.lu" =>
+            {
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                // Funct5 + fmt + rs2
+                instruction.binary = append_binary(instruction.binary, 0b110100000011, 12);
+                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                read_operands_riscv(
+                    instruction,
+                    vec![RegisterFP, RegisterGP],
+                    vec![1, 2],
+                    None,
+                    Some(0b111), // This funct3 is used for the rm value
+                    None
+                );
+
+                // Opcode
+                instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
+                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+
+                //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
+                if monaco_line_info[instruction.line_number]
+                    .mouse_hover_string
+                    .is_empty()
+                {
+                    let info = InstructionDescription{
+                        syntax: "fcvt.s.lu rd, rs1".to_string(),
+                        description: "Converts a single-precision floating-point value to an unsigned 32-bit integer.\n\nTakes the value in a floating-point register (f-register), performs the conversion, and stores the result in an integer register (x-register).".to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
@@ -2509,6 +5522,79 @@ fn immediate_to_stored(mut bin: u32) -> u32
     // Move bits 11-7 to positions 24-20
     let moved_rs2 = rs2 << 20;
 
+    // Combine the manipulated bits
+    bin |=   moved_imm | moved_rs2;
+
+    bin
+}
+
+// Converts an I-type instruction to B-type instruction
+// Easier to encode in this manner
+fn immediate_to_branch(mut bin: u32) -> u32 
+{
+    log!("Binary: ", format!("{:032b}", bin));
+    log!("Immediate: ", format!("{:012b}", (bin >> 20)));
+
+    // Extract bits imm[4:1] from the immediate, last bit is ignored
+    let lower_imm = (bin >> 21) & 0b1111;
+
+    // Extract imm[10:5]
+    let upper_imm = (bin >> 24) & 0b111111;
+
+    // Extract bit 11 and bit 12
+    let bit_11 = (bin >> 30) & 0b1;
+    let bit_12 = (bin >> 31) & 0b1;
+
+    // Extract rs1 and rs2
+    let rs1 = (bin >> 7) & 0b11111;
+    let rs2 = (bin >> 15) & 0b11111;
+
+    // Clear bits 24-20, rs1, and rs2
+    bin &= !((0b11111 << 20) | (0b11111 << 15) | (0b11111 << 7));
+
+    // Move bits imm[4:1] to positions 10-8
+    let moved_lower = lower_imm << 8;
+    
+    let moved_upper = upper_imm << 25;
+
+    let moved_bit_11 = bit_11 << 7;
+
+    let moved_bit_12 = bit_12 << 31;
+
+    // Move rs2 to positions 24-20
+    let moved_rs2 = rs2 << 20;
+
+    // Move rs1 to positions 15-19
+    let moved_rs1 = rs1 << 15;
+
+    // Combine the manipulated bits
+    bin |=   moved_bit_12 | moved_upper | moved_rs2 | moved_rs1 | moved_lower | moved_bit_11;
+
+    bin
+}
+
+// Reorder the immediate value to comply with J-type format
+fn upper_to_jump(mut bin: u32) -> u32
+{
+    // Extract bits 24-20 from the first segment
+    let lower_imm = (bin >> 20) & 0b11111;
+
+    // Extract bits 11-7 from the second segment
+    let rs2 = (bin >> 7) & 0b11111;
+
+    log!("Bits to move (24-20): ", format!("{:05b}", lower_imm));
+    log!("Bits to move (11-7): ", format!("{:05b}", rs2));
+
+    // Clear bits 24-20 and 11-7
+    bin &= !((0b11111 << 20) | (0b11111 << 6));
+
+    log!("Cleared bits: ", format!("{:032b}", bin));
+
+    // Move bits 24-20 to positions 11-7
+    let moved_imm = lower_imm << 7;
+
+    // Move bits 11-7 to positions 24-20
+    let moved_rs2 = rs2 << 20;
 
     // Combine the manipulated bits
     bin |=   moved_imm | moved_rs2;

--- a/src/parser/parser_assembler_main.rs
+++ b/src/parser/parser_assembler_main.rs
@@ -15,7 +15,8 @@ use gloo_console::log;
 /// program and builds the binary of the instructions while cataloging any errors that are found.
 pub fn parser(file_string: String) -> (ProgramInfo, Vec<u32>) {
 
-    let arch = Architecture::RISCV; // Force RISC-V for testing purposes
+    // Force MIPS to pass unit tests until I change the function arguments for SWIMv1 test cases``
+    let arch = Architecture::MIPS;
 
     if arch == Architecture::MIPS
     {

--- a/src/parser/parser_assembler_main.rs
+++ b/src/parser/parser_assembler_main.rs
@@ -14,12 +14,10 @@ use gloo_console::log;
 ///Parser is the starting function of the parser / assembler process. It takes a string representation of a MIPS
 /// program and builds the binary of the instructions while cataloging any errors that are found.
 pub fn parser(file_string: String) -> (ProgramInfo, Vec<u32>) {
-
     // Force MIPS to pass unit tests until I change the function arguments for SWIMv1 test cases``
     let arch = Architecture::MIPS;
 
-    if arch == Architecture::MIPS
-    {
+    if arch == Architecture::MIPS {
         let mut program_info = ProgramInfo {
             monaco_line_info: tokenize_program(file_string),
             ..Default::default()
@@ -75,9 +73,7 @@ pub fn parser(file_string: String) -> (ProgramInfo, Vec<u32>) {
         program_info.pc_starting_point = determine_pc_starting_point(labels);
 
         (program_info.clone(), binary)
-    }
-    else
-    {
+    } else {
         let mut program_info = ProgramInfo {
             monaco_line_info: tokenize_program(file_string),
             ..Default::default()
@@ -1554,19 +1550,21 @@ pub fn read_instructions_riscv(
     instruction_list: &mut [Instruction],
     _labels: &HashMap<String, usize>,
     monaco_line_info: &mut [MonacoLineInfo],
-) 
-{
-    for mut instruction in &mut instruction_list.iter_mut()
-    {
-        match &*instruction.operator.token_name.to_lowercase()
-        {
-            "add" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+) {
+    for mut instruction in &mut instruction_list.iter_mut() {
+        match &*instruction.operator.token_name.to_lowercase() {
+            "add" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1574,12 +1572,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1593,13 +1594,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sub" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sub" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0100000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1607,12 +1613,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1626,13 +1635,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sll" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sll" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1640,12 +1654,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1659,13 +1676,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "slt" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "slt" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1673,12 +1695,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b010),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1692,13 +1717,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sltu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sltu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1706,12 +1736,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b011),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1725,13 +1758,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "xor" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "xor" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1739,12 +1777,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b100),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1758,13 +1799,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "srl" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "srl" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1772,12 +1818,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1791,13 +1840,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sra" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sra" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0100000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1805,12 +1859,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1824,13 +1881,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "or" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "or" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1838,12 +1900,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b110),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1857,13 +1922,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "and" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "and" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1871,12 +1941,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1890,9 +1963,13 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "addi" => // This instruction requires the 12-bit immediate to be sign extended before moving to the emulator's register
+            "addi" =>
+            // This instruction requires the 12-bit immediate to be sign extended before moving to the emulator's register
             {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1900,12 +1977,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1919,9 +1999,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "slti" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "slti" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1929,12 +2011,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b010),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1948,9 +2033,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sltiu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sltiu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1958,12 +2045,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b011),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -1977,9 +2067,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "xori" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "xori" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -1987,12 +2079,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b100),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2006,9 +2101,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "ori" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "ori" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2016,12 +2113,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b110),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2035,9 +2135,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "andi" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "andi" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2045,12 +2147,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2064,9 +2169,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "slli" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "slli" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b00000, 5); // Check if the next 2 bits are needed
@@ -2077,12 +2184,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2096,9 +2206,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "srli" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "srli" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b00000, 5); // Check if the next 2 bits are needed
@@ -2109,12 +2221,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2128,9 +2243,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "srai" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "srai" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b01000, 5); // Check if the next 2 bits are needed
@@ -2141,12 +2258,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2160,9 +2280,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "lb" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "lb" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2170,12 +2292,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b000),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0000011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2189,9 +2314,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "lh" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "lh" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2199,12 +2326,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b001),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0000011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2218,9 +2348,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "lw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "lw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2228,12 +2360,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b010),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0000011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2247,9 +2382,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "lbu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "lbu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2257,12 +2394,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b100),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0000011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2276,9 +2416,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "lhu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "lhu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2286,12 +2428,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0000011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2305,9 +2450,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sb" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sb" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2315,12 +2462,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b000),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0100011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Encoded as I-type, but needs reordering for S-type
                 instruction.binary = immediate_to_stored(instruction.binary);
@@ -2331,16 +2481,20 @@ pub fn read_instructions_riscv(
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "sb rs2, offset(rs1)".to_string(),
-                        description: "Store 8-bit, values from the low bits of register rs2 to memory.".to_string(),
+                        description:
+                            "Store 8-bit, values from the low bits of register rs2 to memory."
+                                .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sh" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sh" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2348,12 +2502,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b001),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0100011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Encoded as I-type, but needs reordering for S-type
                 instruction.binary = immediate_to_stored(instruction.binary);
@@ -2364,16 +2521,20 @@ pub fn read_instructions_riscv(
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "sh rs2, offset(rs1)".to_string(),
-                        description: "Store 16-bit, values from the low bits of register rs2 to memory.".to_string(),
+                        description:
+                            "Store 16-bit, values from the low bits of register rs2 to memory."
+                                .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2381,12 +2542,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b010),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0100011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Encoded as I-type, but needs reordering for S-type
                 instruction.binary = immediate_to_stored(instruction.binary);
@@ -2397,17 +2561,23 @@ pub fn read_instructions_riscv(
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "sw rs2, offset(rs1)".to_string(),
-                        description: "Store 32-bit, values from the low bits of register rs2 to memory.".to_string(),
+                        description:
+                            "Store 32-bit, values from the low bits of register rs2 to memory."
+                                .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "jal" => // Finish J instructions
+            "jal" =>
+            // Finish J instructions
             {
                 log!("jal instruction");
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Read as U-type instruction and reorder immediate value after
                 read_operands_riscv(
@@ -2416,32 +2586,40 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     None,
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1101111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Reorder immediate
                 instruction.binary = upper_to_jump(instruction.binary);
-                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "3. Reordered Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "jal rd, offset".to_string(),
                         description: "Jump to address and place return address in rd.".to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "jalr" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "jalr" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2449,28 +2627,33 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b000),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1100111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "jalr rd, rs1, offset".to_string(),
                         description: "Jump to address and place return address in rd.".to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "beq" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "beq" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2478,31 +2661,40 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 instruction.binary = immediate_to_branch(instruction.binary);
-                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "3. Reordered Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "beq rs1, rs2, offset".to_string(),
-                        description: "Take the branch if registers rs1 and rs2 are equal.".to_string(),
+                        description: "Take the branch if registers rs1 and rs2 are equal."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "bne" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "bne" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2510,31 +2702,40 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 instruction.binary = immediate_to_branch(instruction.binary);
-                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "3. Reordered Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "bne rs1, rs2, offset".to_string(),
-                        description: "Take the branch if registers rs1 and rs2 are not equal.".to_string(),
+                        description: "Take the branch if registers rs1 and rs2 are not equal."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "blt" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "blt" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2542,15 +2743,21 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b100),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 instruction.binary = immediate_to_branch(instruction.binary);
-                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "3. Reordered Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2564,9 +2771,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "bge" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "bge" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2574,15 +2783,21 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 instruction.binary = immediate_to_branch(instruction.binary);
-                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "3. Reordered Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2596,9 +2811,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "bltu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "bltu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2606,15 +2823,21 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b110),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 instruction.binary = immediate_to_branch(instruction.binary);
-                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "3. Reordered Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2628,9 +2851,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "bgeu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "bgeu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2638,15 +2863,21 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1100011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 instruction.binary = immediate_to_branch(instruction.binary);
-                log!("3. Reordered Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "3. Reordered Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2660,13 +2891,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "ecall" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "ecall" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // ecall instruction encoding does not change
                 instruction.binary = 0b00000000000000000000000001110011;
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2680,13 +2916,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "ebreak" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "ebreak" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // ebreak instruction encoding does not change
                 instruction.binary = 0b00000000000100000000000001110011;
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2700,13 +2941,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "uret" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "uret" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // uret instruction encoding does not change
                 instruction.binary = 0b00000000001000000000000001110011;
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2720,13 +2966,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sret" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sret" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // uret instruction encoding does not change
                 instruction.binary = 0b00010000001000000000000001110011;
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2740,13 +2991,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "mret" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "mret" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // uret instruction encoding does not change
                 instruction.binary = 0b00110000001000000000000001110011;
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2760,13 +3016,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "wfi" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "wfi" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // uret instruction encoding does not change
                 instruction.binary = 0b00010000010100000000000001110011;
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2780,13 +3041,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fence.i" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fence.i" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // fence.i instruction encoding does not change
                 instruction.binary = 0b00000000000000000001000000001111;
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2800,9 +3066,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "lui" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "lui" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2810,12 +3078,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     None,
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2829,10 +3100,12 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "auipc" =>
-            {
+            "auipc" => {
                 log!("auipc instruction");
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2840,12 +3113,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     None,
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0010111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2859,9 +3135,13 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "addiw" => // Start of RV64I Instructions
+            "addiw" =>
+            // Start of RV64I Instructions
             {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2869,12 +3149,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0011011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2888,9 +3171,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "slliw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "slliw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
@@ -2901,12 +3186,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0011011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2920,9 +3208,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "srliw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "srliw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
@@ -2933,12 +3223,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0011011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2952,25 +3245,30 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sraiw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sraiw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b01000, 7);
-                
+
                 read_operands_riscv(
                     instruction,
                     vec![RegisterGP, RegisterGP, ShiftAmount],
                     vec![1, 2, 3],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0011011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -2984,13 +3282,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "addw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "addw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -2998,12 +3301,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3017,13 +3323,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "subw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "subw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0100000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3031,12 +3342,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3050,13 +3364,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sllw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sllw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3064,12 +3383,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3083,13 +3405,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "srlw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "srlw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3097,12 +3424,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3116,13 +3446,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sraw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sraw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0100000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3130,12 +3465,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3149,9 +3487,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "lwu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "lwu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3159,12 +3499,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b110),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0000011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3178,9 +3521,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "ld" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "ld" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3188,28 +3533,34 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b011),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0000011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "ld rd, offset(rs1)".to_string(),
-                        description: "Loads a 64-bit value from memory into register rd for RV64I.".to_string(),
+                        description: "Loads a 64-bit value from memory into register rd for RV64I."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "sd" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "sd" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3217,12 +3568,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b011),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0100011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Encoded as I-type, but needs reordering for S-type
                 instruction.binary = immediate_to_stored(instruction.binary);
@@ -3233,20 +3587,28 @@ pub fn read_instructions_riscv(
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "sd rs2, offset(rs1)".to_string(),
-                        description: "Store 64-bit, values from register rs2 to memory.".to_string(),
+                        description: "Store 64-bit, values from register rs2 to memory."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "mul" => // Start of RV32M
+            "mul" =>
+            // Start of RV32M
             {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3254,12 +3616,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3273,13 +3638,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "mulh" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "mulh" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3287,12 +3657,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3307,13 +3680,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "mulhsu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "mulhsu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3321,12 +3699,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b010),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3340,13 +3721,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "mulhu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "mulhu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3354,12 +3740,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b011),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3373,13 +3762,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "div" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "div" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3387,12 +3781,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b100),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3406,13 +3803,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "divu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "divu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3420,12 +3822,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3439,13 +3844,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "rem" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "rem" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3453,12 +3863,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b110),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3472,13 +3885,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "remu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "remu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3486,12 +3904,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0110011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3505,13 +3926,20 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "mulw" => // Start of RV64M
+            "mulw" =>
+            // Start of RV64M
             {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3519,12 +3947,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3538,13 +3969,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "divw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "divw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3552,12 +3988,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b100),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3571,13 +4010,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "divuw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "divuw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3585,12 +4029,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b101),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3604,13 +4051,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "remw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "remw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3618,12 +4070,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b110),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3637,13 +4092,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "remuw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "remuw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct7
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3651,12 +4111,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0111011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3670,9 +4133,13 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmadd.s" => // Start of RV32F
+            "fmadd.s" =>
+            // Start of RV32F
             {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3680,12 +4147,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3, 4],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    Some(0b00)
+                    Some(0b00),
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1000011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3699,9 +4169,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmsub.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fmsub.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3709,12 +4181,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3, 4],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    Some(0b00)
+                    Some(0b00),
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1000111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3728,9 +4203,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fnmsub.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fnmsub.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3738,12 +4215,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3, 4],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    Some(0b00)
+                    Some(0b00),
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1001011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3757,9 +4237,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fnmadd.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fnmadd.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3767,12 +4249,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3, 4],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    Some(0b00)
+                    Some(0b00),
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1001111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3786,13 +4271,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fadd.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fadd.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0000000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3800,32 +4290,41 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fadd.s rd, rs1, rs2".to_string(),
-                        description: "Perform single-precision floating-point addition.".to_string(),
+                        description: "Perform single-precision floating-point addition."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsub.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsub.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0000100, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3833,32 +4332,41 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fsub.s rd, rs1, rs2".to_string(),
-                        description: "Perform single-precision floating-point substraction.".to_string(),
+                        description: "Perform single-precision floating-point substraction."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmul.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fmul.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0001000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3866,32 +4374,41 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fmul.s rd, rs1, rs2".to_string(),
-                        description: "Perform single-precision floating-point multiplication.".to_string(),
+                        description: "Perform single-precision floating-point multiplication."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fdiv.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fdiv.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0001100, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3899,32 +4416,41 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fdiv.s rd, rs1, rs2".to_string(),
-                        description: "Perform single-precision floating-point division.".to_string(),
+                        description: "Perform single-precision floating-point division."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsqrt.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsqrt.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + padding for absent register
                 instruction.binary = append_binary(instruction.binary, 0b010110000000, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3932,32 +4458,40 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fsqrt.s rd, rs1".to_string(),
                         description: "Perform single-precision square root.".to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsgnj.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsgnj.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0010000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3965,12 +4499,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -3984,13 +4521,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsgnjn.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsgnjn.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0010000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -3998,12 +4540,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4017,13 +4562,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsgnjx.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsgnjx.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0010000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4031,12 +4581,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b010), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4050,13 +4603,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmin.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fmin.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0010100, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4064,32 +4622,42 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fmin.s rd, rs1, rs2".to_string(),
-                        description: "Write the smaller of single precision data in rs1 and rs2 to rd.".to_string(),
+                        description:
+                            "Write the smaller of single precision data in rs1 and rs2 to rd."
+                                .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmax.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fmax.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0010100, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4097,32 +4665,42 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fmax.s rd, rs1, rs2".to_string(),
-                        description: "Write the larger of single precision data in rs1 and rs2 to rd.".to_string(),
+                        description:
+                            "Write the larger of single precision data in rs1 and rs2 to rd."
+                                .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.w.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.w.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + padding for absent register
                 instruction.binary = append_binary(instruction.binary, 0b110000000000, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4130,12 +4708,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4149,13 +4730,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.wu.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.wu.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b110000000001, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4163,12 +4749,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4182,13 +4771,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmv.x.w" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fmv.x.w" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b111000000000, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4196,12 +4790,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b000), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4215,13 +4812,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "feq.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "feq.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b1010000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4229,12 +4831,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b010), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4248,13 +4853,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "flt.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "flt.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b1010000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4262,12 +4872,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4281,13 +4894,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fle.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fle.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b1010000, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4295,12 +4913,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4314,13 +4935,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fclass.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fclass.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b111000000000, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4328,12 +4954,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b001), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4347,13 +4976,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.s.w" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.s.w" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b110100000000, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4361,12 +4995,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4380,13 +5017,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.s.wu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.s.wu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b110100000001, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4394,12 +5036,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4413,13 +5058,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmv.w.x" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fmv.w.x" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b111100000000, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4427,12 +5077,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b000), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4446,9 +5099,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmadd.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fmadd.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4456,12 +5111,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3, 4],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    Some(0b01)
+                    Some(0b01),
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1000011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4475,9 +5133,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmsub.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fmsub.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4485,12 +5145,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3, 4],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    Some(0b01)
+                    Some(0b01),
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1000111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4504,9 +5167,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fnmsub.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fnmsub.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4514,12 +5179,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3, 4],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    Some(0b01)
+                    Some(0b01),
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1001011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4533,9 +5201,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fnmadd.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fnmadd.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4543,12 +5213,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3, 4],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    Some(0b01)
+                    Some(0b01),
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1001111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4562,13 +5235,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fadd.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fadd.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0000001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4576,32 +5254,41 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fadd.d rd, rs1, rs2".to_string(),
-                        description: "Perform single-precision floating-point addition.".to_string(),
+                        description: "Perform single-precision floating-point addition."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsub.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsub.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0000101, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4609,32 +5296,41 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fsub.d rd, rs1, rs2".to_string(),
-                        description: "Perform single-precision floating-point subtraction.".to_string(),
+                        description: "Perform single-precision floating-point subtraction."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmul.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fmul.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0001001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4642,32 +5338,41 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fmul.d rd, rs1, rs2".to_string(),
-                        description: "Perform single-precision floating-point multiplication.".to_string(),
+                        description: "Perform single-precision floating-point multiplication."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fdiv.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fdiv.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0001101, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4675,32 +5380,41 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fdiv.d rd, rs1, rs2".to_string(),
-                        description: "Perform single-precision floating-point division.".to_string(),
+                        description: "Perform single-precision floating-point division."
+                            .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsqrt.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsqrt.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b010110100000, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4708,32 +5422,40 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fsqrt.d rd, rs1".to_string(),
                         description: "Perform single-precision square root.".to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsgnj.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsgnj.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0010001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4741,12 +5463,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4760,13 +5485,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsgnjn.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsgnjn.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0010001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4774,12 +5504,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4793,13 +5526,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsgnjx.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsgnjx.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0010001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4807,12 +5545,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b010), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4826,13 +5567,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmin.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fmin.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0010101, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4840,32 +5586,42 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fmin.d rd, rs1, rs2".to_string(),
-                        description: "Write the smaller of single precision data in rs1 and rs2 to rd.".to_string(),
+                        description:
+                            "Write the smaller of single precision data in rs1 and rs2 to rd."
+                                .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fmax.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fmax.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b0010101, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4873,32 +5629,42 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
                     .is_empty()
                 {
-                    let info = InstructionDescription{
+                    let info = InstructionDescription {
                         syntax: "fmax.d rd, rs1, rs2".to_string(),
-                        description: "Write the larger of single precision data in rs1 and rs2 to rd.".to_string(),
+                        description:
+                            "Write the larger of single precision data in rs1 and rs2 to rd."
+                                .to_string(),
                     };
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.s.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.s.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b010000000001, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4906,12 +5672,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4925,13 +5694,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.d.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.d.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b010000100000, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4939,12 +5713,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4958,13 +5735,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "feq.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "feq.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b1010001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -4972,12 +5754,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b010), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -4991,13 +5776,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "flt.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "flt.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b1010001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5005,12 +5795,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b001), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5024,13 +5817,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fle.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fle.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt
                 instruction.binary = append_binary(instruction.binary, 0b1010001, 7);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5038,12 +5836,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2, 3],
                     None,
                     Some(0b000), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5057,13 +5858,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fclass.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fclass.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b111000100000, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5071,12 +5877,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b001), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5090,13 +5899,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.w.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.w.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b110000100000, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5104,12 +5918,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5123,13 +5940,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.wu.d" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.wu.d" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b110000100001, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5137,12 +5959,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5156,13 +5981,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.d.w" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.d.w" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b110100100000, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5170,12 +6000,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5189,13 +6022,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.d.wu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.d.wu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b110100100001, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5203,12 +6041,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5222,9 +6063,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "flw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "flw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5232,12 +6075,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b010),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0000111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5251,9 +6097,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsw" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsw" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5261,12 +6109,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b010),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0100111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Encoded as I-type, but needs reordering for S-type
                 instruction.binary = immediate_to_stored(instruction.binary);
@@ -5284,9 +6135,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fld" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fld" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5294,12 +6147,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b011),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0000111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5313,9 +6169,11 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fsd" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fsd" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5323,12 +6181,15 @@ pub fn read_instructions_riscv(
                     vec![1, 3, 2],
                     None,
                     Some(0b011),
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b0100111, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Encoded as I-type, but needs reordering for S-type
                 instruction.binary = immediate_to_stored(instruction.binary);
@@ -5346,13 +6207,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.l.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.l.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b110000000010, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5360,12 +6226,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5379,13 +6248,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.lu.s" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.lu.s" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b110000000011, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5393,12 +6267,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5412,13 +6289,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.s.l" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.s.l" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b110100000010, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5426,12 +6308,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5445,13 +6330,18 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            "fcvt.s.lu" =>
-            {
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+            "fcvt.s.lu" => {
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 // Funct5 + fmt + rs2
                 instruction.binary = append_binary(instruction.binary, 0b110100000011, 12);
-                log!("Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 read_operands_riscv(
                     instruction,
@@ -5459,12 +6349,15 @@ pub fn read_instructions_riscv(
                     vec![1, 2],
                     None,
                     Some(0b111), // This funct3 is used for the rm value
-                    None
+                    None,
                 );
 
                 // Opcode
                 instruction.binary = append_binary(instruction.binary, 0b1010011, 7);
-                log!("2. Instruction Binary: ", format!("{:032b}", instruction.binary));
+                log!(
+                    "2. Instruction Binary: ",
+                    format!("{:032b}", instruction.binary)
+                );
 
                 //Pseudo-instructions already have text in mouse_hover_string so we check if there's text there already before adding in the blurb
                 if monaco_line_info[instruction.line_number]
@@ -5478,8 +6371,7 @@ pub fn read_instructions_riscv(
                     monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
                 }
             }
-            _ =>
-            {
+            _ => {
                 if UNSUPPORTED_INSTRUCTIONS.contains(&&*instruction.operator.token_name) {
                     instruction.errors.push(Error {
                         error_name: UnsupportedInstruction,
@@ -5501,8 +6393,7 @@ pub fn read_instructions_riscv(
 }
 
 // Reorder store instruction to the correct format
-fn immediate_to_stored(mut bin: u32) -> u32
-{
+fn immediate_to_stored(mut bin: u32) -> u32 {
     // Extract bits 24-20 from the first segment
     let lower_imm = (bin >> 20) & 0b11111;
 
@@ -5524,15 +6415,14 @@ fn immediate_to_stored(mut bin: u32) -> u32
     let moved_rs2 = rs2 << 20;
 
     // Combine the manipulated bits
-    bin |=   moved_imm | moved_rs2;
+    bin |= moved_imm | moved_rs2;
 
     bin
 }
 
 // Converts an I-type instruction to B-type instruction
 // Easier to encode in this manner
-fn immediate_to_branch(mut bin: u32) -> u32 
-{
+fn immediate_to_branch(mut bin: u32) -> u32 {
     log!("Binary: ", format!("{:032b}", bin));
     log!("Immediate: ", format!("{:012b}", (bin >> 20)));
 
@@ -5555,7 +6445,7 @@ fn immediate_to_branch(mut bin: u32) -> u32
 
     // Move bits imm[4:1] to positions 10-8
     let moved_lower = lower_imm << 8;
-    
+
     let moved_upper = upper_imm << 25;
 
     let moved_bit_11 = bit_11 << 7;
@@ -5569,14 +6459,13 @@ fn immediate_to_branch(mut bin: u32) -> u32
     let moved_rs1 = rs1 << 15;
 
     // Combine the manipulated bits
-    bin |=   moved_bit_12 | moved_upper | moved_rs2 | moved_rs1 | moved_lower | moved_bit_11;
+    bin |= moved_bit_12 | moved_upper | moved_rs2 | moved_rs1 | moved_lower | moved_bit_11;
 
     bin
 }
 
 // Reorder the immediate value to comply with J-type format
-fn upper_to_jump(mut bin: u32) -> u32
-{
+fn upper_to_jump(mut bin: u32) -> u32 {
     // Extract bits 24-20 from the first segment
     let lower_imm = (bin >> 20) & 0b11111;
 
@@ -5598,11 +6487,10 @@ fn upper_to_jump(mut bin: u32) -> u32
     let moved_rs2 = rs2 << 20;
 
     // Combine the manipulated bits
-    bin |=   moved_imm | moved_rs2;
+    bin |= moved_imm | moved_rs2;
 
     bin
 }
-
 
 ///This function takes two numbers and inserts the binary of the second at a given index in the binary of the first.
 ///All binary values at and past the insertion index of the original string will be moved to the end of the resultant string.

--- a/src/parser/parser_structs_and_enums.rs
+++ b/src/parser/parser_structs_and_enums.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use std::fmt::Formatter;
 use std::string::ToString;
 
+use gloo_console::log;
+
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 ///Wrapper for all information gathered in the Parser/Assembler about the written program.
 pub struct ProgramInfo {
@@ -13,6 +15,13 @@ pub struct ProgramInfo {
     pub instructions: Vec<Instruction>,
     pub data: Vec<Data>,
     pub pc_starting_point: usize,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum Architecture {
+    #[default]
+    MIPS,
+    RISCV
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -228,6 +237,7 @@ pub enum OperandType {
     RegisterGP,
     RegisterFP,
     Immediate,
+    UpperImmediate,
     MemoryAddress,
     LabelAbsolute,
     LabelRelative,
@@ -235,15 +245,18 @@ pub enum OperandType {
 }
 
 pub const SUPPORTED_INSTRUCTIONS: [&str; 64] = [
+    // MIPS Instructions
     "add", "add.d", "add.s", "addi", "addiu", "addu", "and", "andi", "aui", "b", "bc1f", "bc1t",
     "beq", "bne", "c.eq.d", "c.eq.s", "c.le.d", "c.le.s", "c.lt.d", "c.lt.s", "c.nge.d", "c.nge.s",
     "c.ngt.d", "c.ngt.s", "dadd", "daddi", "daddiu", "daddu", "dahi", "dati", "ddiv", "ddivu",
     "div", "div.d", "div.s", "dmfc1", "dmtc1", "dmul", "dmulu", "dsub", "dsubu", "j", "jal",
     "jalr", "jr", "lui", "lw", "lwc1", "mfc1", "mtc1", "mul", "mul.d", "mul.s", "nop", "or", "ori",
     "sll", "slt", "sltu", "sub", "sub.d", "sub.s", "sw", "swc1",
+    // RISC-V Instructions
 ];
 
 pub const UNSUPPORTED_INSTRUCTIONS: [&str; 408] = [
+    // MIPS Instructions
     "abs.d",
     "abs.ps",
     "abs.s",
@@ -652,6 +665,8 @@ pub const UNSUPPORTED_INSTRUCTIONS: [&str; 408] = [
     "wrpgpr",
     "xor",
     "xori",
+    // RISC-V Instructions
+    
 ];
 
 ///Contains every general purpose register's binary value and the various names they are recognized as. Any reference to gp registers throughout the parser/assembler should reference this array
@@ -927,6 +942,281 @@ pub struct FPRegister<'a> {
     pub binary: u8,
 }
 
+pub struct GPRegisterRiscv<'a> {
+    pub names: &'a [&'a str],
+    pub binary: u8,
+}
+
+///Contains every general purpose register's binary value and the various names they are recognized as. Any reference to gp registers throughout the parser/assembler should reference this array
+pub const RISCV_GP_REGISTERS: &[GPRegisterRiscv; 32] = &[
+    GPRegisterRiscv {
+        names: &["x0", "zero"],
+        binary: 0b00000,
+    },
+    GPRegisterRiscv {
+        names: &["x1", "ra"],
+        binary: 0b00001,
+    },
+    GPRegisterRiscv {
+        names: &["x2", "sp"],
+        binary: 0b00010,
+    },
+    GPRegisterRiscv {
+        names: &["x3", "gp"],
+        binary: 0b00011,
+    },
+    GPRegisterRiscv {
+        names: &["x4", "tp"],
+        binary: 0b00100,
+    },
+    GPRegisterRiscv {
+        names: &["x5", "t0"],
+        binary: 0b00101,
+    },
+    GPRegisterRiscv {
+        names: &["x6", "t1"],
+        binary: 0b00110,
+    },
+    GPRegisterRiscv {
+        names: &["x7", "t2"],
+        binary: 0b00111,
+    },
+    GPRegisterRiscv {
+        names: &["x8", "s0", "fp"],
+        binary: 0b01000,
+    },
+    GPRegisterRiscv {
+        names: &["x9", "s1"],
+        binary: 0b01001,
+    },
+    GPRegisterRiscv {
+        names: &["x10", "a0"],
+        binary: 0b01010,
+    },
+    GPRegisterRiscv {
+        names: &["x11", "a1"],
+        binary: 0b01011,
+    },
+    GPRegisterRiscv {
+        names: &["x12", "a2"],
+        binary: 0b01100,
+    },
+    GPRegisterRiscv {
+        names: &["x13", "a3"],
+        binary: 0b01101,
+    },
+    GPRegisterRiscv {
+        names: &["x14", "a4"],
+        binary: 0b01110,
+    },
+    GPRegisterRiscv {
+        names: &["x15", "a5"],
+        binary: 0b01111,
+    },
+    GPRegisterRiscv {
+        names: &["x16", "a6"],
+        binary: 0b10000,
+    },
+    GPRegisterRiscv {
+        names: &["x17", "a7"],
+        binary: 0b10001,
+    },
+    GPRegisterRiscv {
+        names: &["x18", "s2"],
+        binary: 0b10010,
+    },
+    GPRegisterRiscv {
+        names: &["x19", "s3"],
+        binary: 0b10011,
+    },
+    GPRegisterRiscv {
+        names: &["x20", "s4"],
+        binary: 0b10100,
+    },
+    GPRegisterRiscv {
+        names: &["x21", "s5"],
+        binary: 0b10101,
+    },
+    GPRegisterRiscv {
+        names: &["x22", "s6"],
+        binary: 0b10110,
+    },
+    GPRegisterRiscv {
+        names: &["x23", "s7"],
+        binary: 0b10111,
+    },
+    GPRegisterRiscv {
+        names: &["x24", "s8"],
+        binary: 0b11000,
+    },
+    GPRegisterRiscv {
+        names: &["x25", "s9"],
+        binary: 0b11001,
+    },
+    GPRegisterRiscv {
+        names: &["x26", "s10"],
+        binary: 0b11010,
+    },
+    GPRegisterRiscv {
+        names: &["x27", "s11"],
+        binary: 0b11011,
+    },
+    GPRegisterRiscv {
+        names: &["x28", "t3"],
+        binary: 0b11100,
+    },
+    GPRegisterRiscv {
+        names: &["x29", "t4"],
+        binary: 0b11101,
+    },
+    GPRegisterRiscv {
+        names: &["x30", "t5"],
+        binary: 0b11110,
+    },
+    GPRegisterRiscv {
+        names: &["x31", "t6"],
+        binary: 0b11111,
+    },
+];
+
+
+pub struct FPRegisterRiscv<'a> {
+    pub names: &'a [&'a str],
+    pub binary: u8,
+}
+
+///Contains every floating point register name and binary value. Any reference to fp registers throughout the parser/assembler should reference this array
+pub const RISCV_FP_REGISTERS: &[FPRegisterRiscv; 32] = &[
+    FPRegisterRiscv {
+        names: &["f0", "ft0"],
+        binary: 0b00000,
+    },
+    FPRegisterRiscv {
+        names: &["f1", "ft1"],
+        binary: 0b00001,
+    },
+    FPRegisterRiscv {
+        names: &["f2", "ft2"],
+        binary: 0b00010,
+    },
+    FPRegisterRiscv {
+        names: &["f3", "ft3"],
+        binary: 0b00011,
+    },
+    FPRegisterRiscv {
+        names: &["f4", "ft4"],
+        binary: 0b00100,
+    },
+    FPRegisterRiscv {
+        names: &["f5", "ft5"],
+        binary: 0b00101,
+    },
+    FPRegisterRiscv {
+        names: &["f6", "ft6"],
+        binary: 0b00110,
+    },
+    FPRegisterRiscv {
+        names: &["f7", "ft7"],
+        binary: 0b00111,
+    },
+    FPRegisterRiscv {
+        names: &["f8", "fs0"],
+        binary: 0b01000,
+    },
+    FPRegisterRiscv {
+        names: &["f9", "fs1"],
+        binary: 0b01001,
+    },
+    FPRegisterRiscv {
+        names: &["f10", "fa0"],
+        binary: 0b01010,
+    },
+    FPRegisterRiscv {
+        names: &["f11", "fa1"],
+        binary: 0b01011,
+    },
+    FPRegisterRiscv {
+        names: &["f12", "fa2"],
+        binary: 0b01100,
+    },
+    FPRegisterRiscv {
+        names: &["f13", "fa3"],
+        binary: 0b01101,
+    },
+    FPRegisterRiscv {
+        names: &["f14", "fa4"],
+        binary: 0b01110,
+    },
+    FPRegisterRiscv {
+        names: &["f15", "fa5"],
+        binary: 0b01111,
+    },
+    FPRegisterRiscv {
+        names: &["f16", "fa6"],
+        binary: 0b10000,
+    },
+    FPRegisterRiscv {
+        names: &["f17", "fa7"],
+        binary: 0b10001,
+    },
+    FPRegisterRiscv {
+        names: &["f18", "fs2"],
+        binary: 0b10010,
+    },
+    FPRegisterRiscv {
+        names: &["f19", "fs3"],
+        binary: 0b10011,
+    },
+    FPRegisterRiscv {
+        names: &["f20", "fs4"],
+        binary: 0b10100,
+    },
+    FPRegisterRiscv {
+        names: &["f21", "fs5"],
+        binary: 0b10101,
+    },
+    FPRegisterRiscv {
+        names: &["f22", "fs6"],
+        binary: 0b10110,
+    },
+    FPRegisterRiscv {
+        names: &["f23", "fs7"],
+        binary: 0b10111,
+    },
+    FPRegisterRiscv {
+        names: &["f24", "fs8"],
+        binary: 0b11000,
+    },
+    FPRegisterRiscv {
+        names: &["f25", "fs9"],
+        binary: 0b11001,
+    },
+    FPRegisterRiscv {
+        names: &["f26", "fs10"],
+        binary: 0b11010,
+    },
+    FPRegisterRiscv {
+        names: &["f27", "fs11"],
+        binary: 0b11011,
+    },
+    FPRegisterRiscv {
+        names: &["f28", "ft8"],
+        binary: 0b11100,
+    },
+    FPRegisterRiscv {
+        names: &["f29", "ft9"],
+        binary: 0b11101,
+    },
+    FPRegisterRiscv {
+        names: &["f30", "ft10"],
+        binary: 0b11110,
+    },
+    FPRegisterRiscv {
+        names: &["f31", "ft11"],
+        binary: 0b11111,
+    },
+];
+
 //This enum is just for the read_register_function to determine which register type it should expect
 #[derive(Eq, PartialEq)]
 pub enum RegisterType {
@@ -949,19 +1239,21 @@ pub fn print_vec_of_data(data: Vec<Data>) {
 }
 
 pub fn print_instruction_contents(instruction: Instruction) {
-    println!("Operator: {}", instruction.operator.token_name);
-    print!("Operands: ");
+    log!("Operator: ", instruction.operator.token_name);
+    log!("Operands: ");
     for operand in instruction.operands {
-        print!("{} ", operand.token_name);
+        log!(operand.token_name);
     }
-    println!();
+    log!("");
     for label in instruction.labels {
-        println!("Label: {}", label.token.token_name);
+        log!("Label: ", label.token.token_name);
     }
-    print!("Errors: ");
+    log!("Errors: ");
     for error in instruction.errors {
-        print!("{:?} ", error.error_name);
+        log!(error.error_name.to_string());
     }
+
+    log!("Binary ", instruction.binary);
 }
 
 pub fn print_data_contents(data: Data) {

--- a/src/parser/parser_structs_and_enums.rs
+++ b/src/parser/parser_structs_and_enums.rs
@@ -21,7 +21,7 @@ pub struct ProgramInfo {
 pub enum Architecture {
     #[default]
     MIPS,
-    RISCV
+    RISCV,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -666,7 +666,6 @@ pub const UNSUPPORTED_INSTRUCTIONS: [&str; 408] = [
     "xor",
     "xori",
     // RISC-V Instructions
-    
 ];
 
 ///Contains every general purpose register's binary value and the various names they are recognized as. Any reference to gp registers throughout the parser/assembler should reference this array
@@ -1078,7 +1077,6 @@ pub const RISCV_GP_REGISTERS: &[GPRegisterRiscv; 32] = &[
         binary: 0b11111,
     },
 ];
-
 
 pub struct FPRegisterRiscv<'a> {
     pub names: &'a [&'a str],

--- a/static/assembly_examples/riscv_test.asm
+++ b/static/assembly_examples/riscv_test.asm
@@ -1,4 +1,3 @@
-# Currently there is a problem with using tabs to space out instructions
 main:
- jal x1, 50
- ret
+    jal x1, 2047
+    ret

--- a/static/assembly_examples/riscv_test.asm
+++ b/static/assembly_examples/riscv_test.asm
@@ -1,0 +1,4 @@
+# Currently there is a problem with using tabs to space out instructions
+main:
+ jal x1, 50
+ ret


### PR DESCRIPTION
Currently I am forcing the parser to only target MIPS to pass test cases. Once I change the main parser function parameters, I will need to reflect that change for all current MIPS test cases.