### PR TITLE
Update rust version to 1.77

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "swim"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.77"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.67"
+channel = "1.77"
 components = [ "rustc", "cargo", "rustfmt", "rust-std", "rust-docs", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "default"


### PR DESCRIPTION
Updates Rust to the most stable version since [Bumpalo](https://crates.io/crates/bumpalo), which is a `wasm-bindgen` dependency, supports Rust versions > 1.73 as of March 7.

PR #357 fixes the errors from clippy for this update.