### PR TITLE
Parser updates: Change encoding of B-type and J-type instructions.

### DIFF
--- a/src/parser/assembling.rs
+++ b/src/parser/assembling.rs
@@ -257,9 +257,7 @@ pub fn read_operands_riscv(
                     instruction.errors.push(immediate_results.1.unwrap());
                 }
             }
-            UpperImmediate =>
-            // Can be used to represent offsets for J-type instructions
-            {
+            UpperImmediate => {
                 instruction.operands[i].token_type = TokenType::Immediate;
                 bit_lengths.push(20); // 20 bits to represent upper immediates
 

--- a/src/parser/assembling.rs
+++ b/src/parser/assembling.rs
@@ -312,7 +312,7 @@ pub fn read_operands_riscv(
             LabelAbsolute => {
                 instruction.operands[i].token_type = TokenType::LabelOperand;
 
-                bit_lengths.push(26);
+                bit_lengths.push(20);
                 let label_absolute_results = read_label_absolute(
                     &instruction.operands[i].token_name,
                     instruction.operands[i].start_end_columns,
@@ -327,7 +327,7 @@ pub fn read_operands_riscv(
             LabelRelative => {
                 instruction.operands[i].token_type = TokenType::LabelOperand;
 
-                bit_lengths.push(16);
+                bit_lengths.push(12);
                 let label_relative_results = read_label_relative(
                     &instruction.operands[i].token_name,
                     instruction.operands[i].start_end_columns,

--- a/src/parser/parser_assembler_main.rs
+++ b/src/parser/parser_assembler_main.rs
@@ -2296,9 +2296,9 @@ pub fn read_instructions_riscv(
                 instruction.binary = append_binary(instruction.binary, 0b1101111, 7);
 
                 // Reorder immediate
-                instruction.binary = upper_to_jump(instruction.binary);
+                //instruction.binary = upper_to_jump(instruction.binary);
 
-                // This isn't accurate to the risc-v spec, but we can make the user aware of this change in the instruction description
+                // This isn't accurate to the risc-v spec, but we can make the user aware of this change in the instruction description. Unsure how useful this may be to the end user.
 
                 if monaco_line_info[instruction.line_number]
                     .mouse_hover_string
@@ -5006,7 +5006,7 @@ fn _immediate_to_branch(mut bin: u32) -> u32 {
 }
 
 // Reorder the immediate value to comply with J-type format
-fn upper_to_jump(mut bin: u32) -> u32 {
+fn _upper_to_jump(mut bin: u32) -> u32 {
     // Extract bits immediate
     let imm = bin >> 12;
 

--- a/src/parser/pseudo_instruction_parsing.rs
+++ b/src/parser/pseudo_instruction_parsing.rs
@@ -1898,7 +1898,7 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers_riscv(
                 let info = PseudoDescription {
                     name: "jr".to_string(),
                     syntax: "jr offset".to_string(),
-                    translation_lines: vec!["jal x1, offset".to_string()],
+                    translation_lines: vec!["jalr x0, rs, 0".to_string()],
                 };
                 monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
 
@@ -1923,17 +1923,22 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers_riscv(
                 // Update Line Info
                 //monaco_line_info[instruction.line_number].update_pseudo_string(vec![instruction]);
             }
-            "ret" => {
+            "jalr" => {
+                // Account for default jal instruction
+                if instruction.operands.len() != 1 {
+                    continue;
+                }
+
                 // Set Pseudo Description
                 let info = PseudoDescription {
-                    name: "ret".to_string(),
-                    syntax: "ret".to_string(),
-                    translation_lines: vec!["jalr x1, 0(x0)".to_string()],
+                    name: "jalr".to_string(),
+                    syntax: "jalr rs".to_string(),
+                    translation_lines: vec!["jalr x1, rs, 0".to_string()],
                 };
                 monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
 
                 // Check operands
-                if !check_operands(instruction, 0) {
+                if !check_operands(instruction, 1) {
                     continue;
                 }
 
@@ -1950,9 +1955,55 @@ pub fn expand_pseudo_instructions_and_assign_instruction_numbers_riscv(
                     },
                 );
                 instruction.operands.insert(
+                    2,
+                    Token {
+                        token_name: "0".to_string(),
+                        start_end_columns: (0, 0),
+                        token_type: Default::default(),
+                    },
+                );
+
+                // Update Line Info
+                //monaco_line_info[instruction.line_number].update_pseudo_string(vec![instruction]);
+            }
+            "ret" => {
+                // Set Pseudo Description
+                let info = PseudoDescription {
+                    name: "ret".to_string(),
+                    syntax: "ret".to_string(),
+                    translation_lines: vec!["jalr x0, x1, 0".to_string()],
+                };
+                monaco_line_info[instruction.line_number].mouse_hover_string = info.to_string();
+
+                // Check operands
+                if !check_operands(instruction, 0) {
+                    continue;
+                }
+
+                // Replace Instruction
+                instruction.operator.token_name = "jalr".to_string();
+
+                // Replace Operands
+                instruction.operands.insert(
+                    0,
+                    Token {
+                        token_name: "x0".to_string(),
+                        start_end_columns: (0, 0),
+                        token_type: Default::default(),
+                    },
+                );
+                instruction.operands.insert(
                     1,
                     Token {
-                        token_name: "0(x0)".to_string(),
+                        token_name: "x1".to_string(),
+                        start_end_columns: (0, 0),
+                        token_type: Default::default(),
+                    },
+                );
+                instruction.operands.insert(
+                    2,
+                    Token {
+                        token_name: "0".to_string(),
                         start_end_columns: (0, 0),
                         token_type: Default::default(),
                     },

--- a/src/tests/parser/parser_assembler_main.rs
+++ b/src/tests/parser/parser_assembler_main.rs
@@ -363,7 +363,7 @@ mod read_riscv_instructions_tests {
 
         assert_eq!(
             instruction_list[0].binary,
-            0b00000000001000000000000011101111
+            0b00000000000000000010000011101111
         );
     }
 

--- a/src/tests/parser/parser_assembler_main.rs
+++ b/src/tests/parser/parser_assembler_main.rs
@@ -357,19 +357,19 @@ mod read_riscv_instructions_tests {
 
     #[test]
     fn read_instructions_jal() {
-        let file_string = "jal x1, 2044".to_string();
+        let file_string = "main:\njal x1, L1\nret\nL1:\nadd x1, x2, x3".to_string();
 
         let instruction_list = instruction_parser_riscv(file_string);
 
         assert_eq!(
             instruction_list[0].binary,
-            0b01111111110000000000000011101111
+            0b00000000001000000000000011101111
         );
     }
 
     #[test]
     fn read_instructions_jalr() {
-        let file_string = "jalr x2, 128(x3)".to_string();
+        let file_string = "jalr x2, x3, 128".to_string();
 
         let instruction_list = instruction_parser_riscv(file_string);
 
@@ -381,73 +381,73 @@ mod read_riscv_instructions_tests {
 
     #[test]
     fn read_instructions_beq() {
-        let file_string = "beq x4, x5, 256".to_string();
+        let file_string = "main:\nbeq x1, x2, L1\nret\nL1:\nadd x1, x2, x3".to_string();
 
         let instruction_list = instruction_parser_riscv(file_string);
 
         assert_eq!(
             instruction_list[0].binary,
-            0b00010000010100100000000001100011
+            0b00000000000100010000000011100011
         );
     }
 
     #[test]
     fn read_instructions_bne() {
-        let file_string = "bne x6, x7, 512".to_string();
+        let file_string = "main:\nbne x1, x2, L1\nret\nL1:\nadd x1, x2, x3".to_string();
 
         let instruction_list = instruction_parser_riscv(file_string);
 
         assert_eq!(
             instruction_list[0].binary,
-            0b00100000011100110001000001100011
+            0b00000000000100010001000011100011
         );
     }
 
     #[test]
     fn read_instructions_blt() {
-        let file_string = "blt x8, x9, 1024".to_string();
+        let file_string = "main:\nblt x1, x2, L1\nret\nL1:\nadd x1, x2, x3".to_string();
 
         let instruction_list = instruction_parser_riscv(file_string);
 
         assert_eq!(
             instruction_list[0].binary,
-            0b01000000100101000100000011100011
+            0b00000000000100010100000011100011
         );
     }
 
     #[test]
     fn read_instructions_bge() {
-        let file_string = "bge x10, x11, 256".to_string();
+        let file_string = "main:\nbge x1, x2, L1\nret\nL1:\nadd x1, x2, x3".to_string();
 
         let instruction_list = instruction_parser_riscv(file_string);
 
         assert_eq!(
             instruction_list[0].binary,
-            0b00010000101101010101000001100011
+            0b00000000000100010101000011100011
         );
     }
 
     #[test]
     fn read_instructions_bltu() {
-        let file_string = "bltu x12, x13, 64".to_string();
+        let file_string = "main:\nbltu x1, x2, L1\nret\nL1:\nadd x1, x2, x3".to_string();
 
         let instruction_list = instruction_parser_riscv(file_string);
 
         assert_eq!(
             instruction_list[0].binary,
-            0b00000100110101100110000001100011
+            0b00000000000100010110000011100011
         );
     }
 
     #[test]
     fn read_instructions_bgeu() {
-        let file_string = "bgeu x14, x15, 32".to_string();
+        let file_string = "main:\nbgeu x1, x2, L1\nret\nL1:\nadd x1, x2, x3".to_string();
 
         let instruction_list = instruction_parser_riscv(file_string);
 
         assert_eq!(
             instruction_list[0].binary,
-            0b00000010111101110111000001100011
+            0b00000000000100010111000011100011
         );
     }
 

--- a/static/assembly_examples/riscv_test.asm
+++ b/static/assembly_examples/riscv_test.asm
@@ -1,5 +1,5 @@
 main:
-    jalr x1
+    jal x1, L1
     bgeu x1, x2, L1
     ret
 

--- a/static/assembly_examples/riscv_test.asm
+++ b/static/assembly_examples/riscv_test.asm
@@ -1,4 +1,7 @@
 main:
-    jal x1, 2044
-    fmv.s f1, f2
+    jalr x1
+    bgeu x1, x2, L1
     ret
+
+L1:
+    add x1, x2, x3


### PR DESCRIPTION
B-type instructions are encoded as I-type instructions and J-type instructions (just JAL) are encoded as U-type instructions.