### PR TITLE
Fixes issue with hover instructions

### DIFF
--- a/src/agent/datapath_reducer.rs
+++ b/src/agent/datapath_reducer.rs
@@ -122,7 +122,7 @@ impl Reducible for DatapathReducer {
                     ..(*self).clone()
                 },
                 SystemUpdate::UpdateSpeed(speed) => Self {
-                    current_architecture: self.current_architecture.clone(),
+                    current_architecture: self.current_architecture,
                     mips: self.mips.clone(),
                     messages: self.messages.clone(),
                     speed,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -124,13 +124,11 @@ fn app(props: &AppProps) -> Html {
                 let text_model = text_model.clone();
                 log!(format!(
                     "Current arch: {:?}",
-                    datapath_state.current_architecture.clone()
+                    datapath_state.current_architecture
                 ));
                 // parses through the code to assemble the binary and retrieves programinfo for error marking and mouse hover
-                let (program_info, assembled, labels) = parser(
-                    text_model.get_value(),
-                    datapath_state.current_architecture.clone(),
-                );
+                let (program_info, assembled, labels) =
+                    parser(text_model.get_value(), datapath_state.current_architecture);
                 *program_info_ref.borrow_mut() = program_info.clone();
                 *binary_ref.borrow_mut() = assembled.clone();
                 *labels_ref.borrow_mut() = labels.clone();
@@ -180,10 +178,8 @@ fn app(props: &AppProps) -> Html {
                     text_model.set_value(&program_info.updated_monaco_string); // Expands pseudo-instructions to their hardware counterpart.
 
                     // After adding pseudo instructions, update program info
-                    let (program_info, assembled, labels) = parser(
-                        text_model.get_value(),
-                        datapath_state.current_architecture.clone(),
-                    );
+                    let (program_info, assembled, labels) =
+                        parser(text_model.get_value(), datapath_state.current_architecture);
                     *program_info_ref.borrow_mut() = program_info.clone();
                     *binary_ref.borrow_mut() = assembled.clone();
                     *labels_ref.borrow_mut() = labels.clone();
@@ -224,10 +220,8 @@ fn app(props: &AppProps) -> Html {
         use_callback(
             move |_, (editor_curr_line, memory_curr_instr, text_model, datapath_state)| {
                 // Get the current line and convert it to f64
-                let (program_info, assembled, labels) = parser(
-                    text_model.get_value(),
-                    datapath_state.current_architecture.clone(),
-                );
+                let (program_info, assembled, labels) =
+                    parser(text_model.get_value(), datapath_state.current_architecture);
                 *program_info_ref.borrow_mut() = program_info.clone();
                 *binary_ref.borrow_mut() = assembled.clone();
                 *labels_ref.borrow_mut() = labels.clone();
@@ -286,10 +280,8 @@ fn app(props: &AppProps) -> Html {
                     // highlight on InstructionDecode since syscall stops at that stage.
 
                     // highlight on InstructionDecode since syscall stops at that stage.
-                    let (program_info, assembled, labels) = parser(
-                        text_model.get_value(),
-                        datapath_state.current_architecture.clone(),
-                    );
+                    let (program_info, assembled, labels) =
+                        parser(text_model.get_value(), datapath_state.current_architecture);
                     *program_info_ref.borrow_mut() = program_info.clone();
                     *binary_ref.borrow_mut() = assembled.clone();
                     *labels_ref.borrow_mut() = labels.clone();
@@ -328,10 +320,8 @@ fn app(props: &AppProps) -> Html {
         let datapath_state = datapath_state.clone();
         use_callback(
             move |_, (text_model, datapath_state)| {
-                let (program_info, assembled, labels) = parser(
-                    text_model.get_value(),
-                    datapath_state.current_architecture.clone(),
-                );
+                let (program_info, assembled, labels) =
+                    parser(text_model.get_value(), datapath_state.current_architecture);
                 *program_info_ref.borrow_mut() = program_info.clone();
                 *binary_ref.borrow_mut() = assembled.clone();
                 *labels_ref.borrow_mut() = labels.clone();
@@ -403,10 +393,8 @@ fn app(props: &AppProps) -> Html {
                             }
                         }
                         // Memory updated successfully
-                        let (program_info, _assembled, _labels) = parser(
-                            text_model.get_value(),
-                            datapath_state.current_architecture.clone(),
-                        );
+                        let (program_info, _assembled, _labels) =
+                            parser(text_model.get_value(), datapath_state.current_architecture);
                         let mut lines_beyond_counter = program_info.address_to_line_number.len();
                         let mut curr_value = text_model.get_value();
                         let mut add_new_lines = false;
@@ -479,10 +467,8 @@ fn app(props: &AppProps) -> Html {
                 }
 
                 // Update the parsed info for text and data segment views
-                let (program_info, _, _) = parser(
-                    text_model.get_value(),
-                    datapath_state.current_architecture.clone(),
-                );
+                let (program_info, _, _) =
+                    parser(text_model.get_value(), datapath_state.current_architecture);
                 *program_info_ref.borrow_mut() = program_info;
 
                 trigger.force_update();
@@ -635,7 +621,7 @@ fn app(props: &AppProps) -> Html {
                             console_active_tab={console_active_tab.clone()}
                             pc={datapath_state.get_pc()}
                             communicator={props.communicator}
-                            current_architecture={datapath_state.current_architecture.clone()}
+                            current_architecture={datapath_state.current_architecture}
                             speed={datapath_state.speed}
                             sp={datapath_state.get_sp()}
                             memory={datapath_state.get_memory().clone()}

--- a/src/emulation_core/architectures.rs
+++ b/src/emulation_core/architectures.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, EnumIter)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, EnumIter, Copy)]
 pub enum AvailableDatapaths {
     MIPS,
     RISCV,

--- a/src/ui/hex_editor/component.rs
+++ b/src/ui/hex_editor/component.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use std::ops::Deref;
 use std::rc::Rc;
 use wasm_bindgen::JsCast;
@@ -152,7 +151,7 @@ pub fn hex_editor(props: &HexEditorProps) -> Html {
         use_callback(
             move |editor_link: CodeEditorLink,
                   (memory, memory_text_model, memory_curr_instr, initialized)| {
-                let result = editor_link.with_editor(|editor| {
+                editor_link.with_editor(|editor| {
                     let hexdump = memory.generate_formatted_hex(CAPACITY_BYTES);
                     memory_text_model.set_value(&hexdump);
 
@@ -196,10 +195,6 @@ pub fn hex_editor(props: &HexEditorProps) -> Html {
                         raw_editor.delta_decorations(&not_highlighted, &executed_line);
                     }
                 });
-                match result {
-                    Some(()) => debug!("Hex Editor linked!"),
-                    None => debug!("No editor :<"),
-                };
             },
             (
                 props.memory.clone(),


### PR DESCRIPTION
The mouse event that is called when hovering over an instruction was not calling the `parser` function to generate program info. This has been re-added.

I've also removed debug logs that are no longer needed, and added the `Copy` trait to `AvailableDatapaths` as recommended by clippy.