### PR TITLE
Riscv fpu fixes

### DIFF
--- a/src/emulation_core/riscv/coprocessor.rs
+++ b/src/emulation_core/riscv/coprocessor.rs
@@ -510,9 +510,9 @@ impl RiscFpCoprocessor {
 
         self.state.data_writeback = match self.signals.data_src {
             DataSrc::MainProcessorUnit => match self.state.rs2 {
-                0 => f32::to_bits(self.data as i32 as f32) as u64,
-                1 => f32::to_bits(self.data as u32 as f32) as u64,
-                2 => f32::to_bits(self.data as i64 as f32) as u64,
+                0 => f32::to_bits(self.data as i32 as f32) as i32 as u64,
+                1 => f32::to_bits(self.data as u32 as f32) as i32 as u64,
+                2 => f32::to_bits(self.data as i64 as f32) as i32 as u64,
                 3 => f32::to_bits(self.data as f32) as u64,
                 _ => {
                     self.error(&format!(
@@ -568,7 +568,7 @@ impl RiscFpCoprocessor {
                         {
                             2_u64.pow(32) - 1
                         } else {
-                            data_rounded as u32 as u64
+                            data_rounded as i32 as u64
                         }
                     }
                     2 => {
@@ -582,19 +582,19 @@ impl RiscFpCoprocessor {
                         {
                             (2_i64.pow(63) - 1) as u64
                         } else {
-                            data_rounded as i64 as u64
+                            data_rounded as i32 as u64
                         }
                     }
                     3 => {
                         if (data_rounded <= 0.0) | (data_rounded == f32::NEG_INFINITY) {
                             0
-                        } else if (data_rounded >= (0x1111111111111111_i64) as f32)
+                        } else if (data_rounded >= (0xffffffffffffffff_u64) as f32)
                             | (data_rounded == f32::INFINITY)
                             | (data_rounded.is_nan())
                         {
-                            0x1111111111111111
+                            0xffffffffffffffff
                         } else {
-                            data_rounded as u64
+                            data_rounded as i32 as u64
                         }
                     }
                     _ => {
@@ -606,7 +606,7 @@ impl RiscFpCoprocessor {
                     }
                 }
             }
-            DataSrc::MainProcessorBits => self.data as u32 as u64,
+            DataSrc::MainProcessorBits => self.data as i32 as u64,
             _ => self.data,
         }
     }

--- a/static/assembly_examples/riscv_fpu_sign_bits.asm
+++ b/static/assembly_examples/riscv_fpu_sign_bits.asm
@@ -1,0 +1,26 @@
+main:
+        # Since Printing Negatives To The Console is a bit Temperamental at the moment, use the Registers with Float mode to check values.
+        # Sign Bit Operations Check
+
+        addi t0, zero, 13
+        addi t1, zero, 7
+        addi t2, zero, -5
+        addi t3, zero, -3
+
+        fcvt.s.w ft0, t0
+        fcvt.s.w ft1, t1
+        fcvt.s.w ft2, t2
+        fcvt.s.w ft3, t3
+
+        # Check Sign Bit Normal (Should be Negative 13 in Register)
+        fsgnj.s ft4, ft0, ft2
+        # Check Sign Bit Negation (Should be Negative 7 in Register)
+        fsgnjn.s ft5, ft1, ft0
+        # Check Sign Bit Xor Both (Should be Positive 5 in Register)
+        fsgnjx.s ft6, ft2, ft3
+        # Check Sign Bit Xor Neither (Should be Positive 13 in Register)
+        fsgnjx.s ft7, ft0, ft1
+        # Check Sign Bit Xor One (Should be Negative 3 in Register)
+        fsgnjx.s ft8, ft3, ft0
+
+        ecall


### PR DESCRIPTION
Some of the sign extensions weren't working entirely correctly (It only affected one specific operation in a very rare case which is why I didn't catch it before). I also re-did how the FSGNJ operations work, since they were behaving poorly. I also added a simplistic RISC-V assembly file to test them. This is the last functional update I'm making to the RISC-V core, I'm moving on now to fixing up the comments/documentation and maybe creating a larger, more comprehensive FPU test assembly file for the program that moves through every FPU operation.